### PR TITLE
Disaggregate prerequisites

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install on macOS
       if: contains(matrix.os, 'macos')
       run: |
-        brew install gcc@${GCC_V} coreutils
+        brew install gcc@${GCC_V} coreutils pkg-config
         sudo ln -s $(which gfortran-${GCC_V}) $(dirname $(which gfortran-${GCC_V}))/gfortran
         yes | ./install.sh --prefix=${PREFIX}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,14 +32,14 @@ jobs:
         --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
         --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_V} \
         --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
-        ./install.sh --prefix=${PREFIX}
+        yes | ./install.sh --prefix=${PREFIX}
 
     - name: Install on macOS
       if: contains(matrix.os, 'macos')
       run: |
         brew install gcc@${GCC_V} coreutils
         sudo ln -s $(which gfortran-${GCC_V}) $(dirname $(which gfortran-${GCC_V}))/gfortran
-        ./install.sh --prefix=${PREFIX}
+        yes | ./install.sh --prefix=${PREFIX}
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install on Ubuntu
       if: contains(matrix.os, 'ubuntu')
       run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         yes | ./install.sh --prefix=${PREFIX}
 
     - name: Install on macOS

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,7 @@ jobs:
       matrix:
         os: [macOS-11, ubuntu-latest]
 
-
     env:
-      GCC_V: 11
       PREFIX: install
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,18 +27,11 @@ jobs:
     - name: Install on Ubuntu
       if: contains(matrix.os, 'ubuntu')
       run: |
-        sudo apt install -y pkg-config gfortran-${GCC_V}
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
-        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
-        --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_V} \
-        --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
         yes | ./install.sh --prefix=${PREFIX}
 
     - name: Install on macOS
       if: contains(matrix.os, 'macos')
       run: |
-        brew install gcc@${GCC_V} coreutils pkg-config
-        sudo ln -s $(which gfortran-${GCC_V}) $(dirname $(which gfortran-${GCC_V}))/gfortran
         yes | ./install.sh --prefix=${PREFIX}
 
     - name: Run unit tests

--- a/install.sh
+++ b/install.sh
@@ -169,8 +169,9 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
   CC=`which gcc-$GCC_VER`
   CXX=`which g++-$GCC_VER`
   FC=`which gfortran-$GCC_VER`
-  PREFIX=`realpath $PREFIX`
 fi
+
+PREFIX=`realpath $PREFIX`
 
 export FPM_FC="$FC"
 export FPM_CC="$CC"

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,8 @@ print_usage_info()
     echo " --prereqs          Display a list of prerequisite software."
     echo "                    Default prefix='\$HOME/.local/bin'"
     echo ""
+    echo "For a non-interactive build with the 'yes' utility installed, execute"
+    echo "yes | ./install.sh"
 }
 
 GCC_VERSION=11

--- a/install.sh
+++ b/install.sh
@@ -61,12 +61,6 @@ done
 
 set -u # error on use of undefined variable
 
-PREFIX=${PREFIX:-"$HOME/.local"}
-echo "Using installation prefix $PREFIX"
-
-PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-"$PREFIX/lib/pkgconfig"}
-echo "Using pkg-config prefix $PKG_CONFIG_PATH"
-
 if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
   if command -v gfortran-$GCC_VER > /dev/null 2>&1; then
     FC=`which gfortran-$GCC_VER`
@@ -125,6 +119,12 @@ ask_permission_to_install_homebrew_package()
   fi
   printf "Is it ok to use Homebrew to install $1? [yes] "
 }
+
+PREFIX=${PREFIX:-"$HOME/.local"}
+echo "Using installation prefix $PREFIX"
+
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-"$PREFIX/lib/pkgconfig"}
+echo "Using pkg-config prefix $PKG_CONFIG_PATH"
 
 exit_if_user_declines()
 {
@@ -280,8 +280,8 @@ echo "${FPM_TOML_LINK_ENTRY}" >> build/fpm.toml
 ln -f -s build/fpm.toml
 
 cd "$PKG_CONFIG_PATH"
-  echo "CAFFEINE_FC=$FC"                                            >  caffeine.pc
   echo "CAFFEINE_FPM_LDFLAGS=$GASNET_LDFLAGS $GASNET_LIB_LOCATIONS" >> caffeine.pc
+  echo "CAFFEINE_FPM_FC=$FC"                                            >  caffeine.pc
   echo "CAFFEINE_FPM_CC=$GASNET_CC"                                 >> caffeine.pc
   echo "CAFFEINE_FPM_CFLAGS=$GASNET_CFLAGS $GASNET_CPPFLAGS"        >> caffeine.pc
   echo "Name: caffeine"                                             >> caffeine.pc
@@ -291,10 +291,10 @@ cd "$PKG_CONFIG_PATH"
 cd -
 
 cd build
-  echo "#!/bin/sh"                                                             >  run-fpm.sh
-  echo "#-- DO NOT EDIT -- created by caffeine/install.sh"                     >> run-fpm.sh
-  echo "\"${FPM}\" \$@ \\"                                                     >> run-fpm.sh
-  echo "--compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FC`\"       \\"  >> run-fpm.sh
+  echo "#!/bin/sh"                                                              >  run-fpm.sh
+  echo "#-- DO NOT EDIT -- created by caffeine/install.sh"                      >> run-fpm.sh
+  echo "\"${FPM}\" \$@ \\"                                                      >> run-fpm.sh
+  echo "--compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`\"   \\"  >> run-fpm.sh
   echo "--c-compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`\" \\"  >> run-fpm.sh
   echo "--c-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`\" \\"  >> run-fpm.sh
   echo "--link-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`\"" >> run-fpm.sh

--- a/install.sh
+++ b/install.sh
@@ -251,10 +251,6 @@ export PKG_CONFIG_PATH
 if ! $PKG_CONFIG $pkg ; then
   ask_package_permission "GASNet-EX" "PKG_CONFIG_PATH"
   exit_if_user_declines "GASNet-EX"
-  if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
-    echo "Installation declined."
-    echo "Caffeine was not installed."
-  fi
 
   GASNET_TAR_FILE="GASNet-$GASNET_VERSION.tar.gz"
   GASNET_SOURCE_URL="https://gasnet.lbl.gov/EX/GASNet-$GASNET_VERSION.tar.gz"

--- a/install.sh
+++ b/install.sh
@@ -92,6 +92,7 @@ if command -v make > /dev/null 2>&1; then
 fi
 
 if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
+  echo ""
   echo "One or more of the following prerequisites was not found:"
   echo "gfortran $GCC_VER, gcc $GCC_VER, g++ $GCC_VER, pkg-config, realpath, make"
   echo ""
@@ -117,7 +118,9 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
       exit 1
     fi
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    BREW_COMMAND=/home/linuxbrew/.linuxbrew/bin/brew
+    if [ $(uname) == "Linux" ]; then
+      BREW_COMMAND=/home/linuxbrew/.linuxbrew/bin/brew
+    fi
   fi
   "$BREW_COMMAND" install pkg-config coreutils gcc@$GCC_VER
   CC=`which gcc-$GCC_VER`

--- a/install.sh
+++ b/install.sh
@@ -145,8 +145,9 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
       exit 1
     fi
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    if [ $(uname) == "Linux" ]; then
+    if [ $(uname) = "Linux" ]; then
       BREW_COMMAND=/home/linuxbrew/.linuxbrew/bin/brew
+      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
     fi
   fi
 
@@ -160,10 +161,12 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
     exit_if_user_declines 
     "$BREW_COMMAND" install pkg-config
   fi
+
   if [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
     ask_homebrew_package_permission "'realpath' and 'make'" "coreutils"
     exit_if_user_declines 
     "$BREW_COMMAND" install coreutils
+    which $BREW_COMMAND
   fi
 
   CC=`which gcc-$GCC_VER`

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/bin/sh
 
 set -e # exit on error
 
@@ -11,11 +11,30 @@ usage()
     echo ""
     echo " --help             Display this help text"
     echo " --prefix=PREFIX    Install binary in 'PREFIX/bin'"
+    echo " --prereqs          Display a list of prerequisite software."
     echo "                    Default prefix='\$HOME/.local/bin'"
     echo ""
 }
 
-PREFIX="$HOME/.local"
+GCC_VER=11
+FPM_VERSION="0.5.0"
+
+prerequisites()
+{
+    echo "Caffeine and this installer were developed with the following prerequisite package" 
+    echo "versions, which also indicate the versions that the installer will install if"
+    echo "missing and if granted permission:"
+    echo ""
+    echo "  GCC $GCC_VER"
+    echo "  GASNet-EX 2021.9.1 (gex-stable-2022_01_11-0-g66a0eaf) s"
+    echo "  fpm $FPM_VERSION"
+    echo "  pkg-config 0.29.2"
+    echo "  realpath 9.0 (Homebrew coreutils 9.0)"
+    echo "  GNU Make 3.1"
+    echo ""
+    echo "In some cases, earlier versions might also work."
+}
+
 
 while [ "$1" != "" ]; do
     PARAM=$(echo "$1" | awk -F= '{print $1}')
@@ -23,6 +42,10 @@ while [ "$1" != "" ]; do
     case $PARAM in
         -h | --help)
             usage
+            exit
+            ;;
+        --prereqs)
+            prerequisites
             exit
             ;;
         --prefix)
@@ -38,63 +61,128 @@ while [ "$1" != "" ]; do
 done
 
 set -u # error on use of undefined variable
-GCC_VER=11
 
-if ! command -v gcc-$GCC_VER > /dev/null 2>&1 \
-    || ! command -v g++-$GCC_VER > /dev/null 2>&1 \
-    || ! command -v gfortran-$GCC_VER > /dev/null 2>&1 \
-    || ! command -v pkg-config > /dev/null 2>&1 \
-    || ! command -v realpath > /dev/null 2>&1 \
-    || ! command -v make > /dev/null 2>&1; then
-  if ! command -v curl > /dev/null 2>&1; then
-    echo "No download mechanism found. Please install curl and rerun ./install.sh"
+if [ -z ${PREFIX+x} ] ; then
+  PREFIX="$HOME/.local"
+  echo "Using default installation prefix: $PREFIX"
+fi
+
+if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
+  if command -v gfortran-$GCC_VER > /dev/null 2>&1; then
+    FC=gfortran-$GCC_VER
+  fi
+  if command -v gcc-$GCC_VER > /dev/null 2>&1; then
+    CC=gcc-$GCC_VER
+  fi
+  if command -v g++-$GCC_VER > /dev/null 2>&1; then
+    CXX=g++-$GCC_VER
+  fi
+fi
+
+if command -v pkg-config > /dev/null 2>&1; then
+  PKG_CONFIG=pkg-config
+fi
+  
+if command -v realpath > /dev/null 2>&1; then
+  REALPATH=realpath
+fi
+
+if command -v make > /dev/null 2>&1; then
+  MAKE=make
+fi
+
+if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
+  echo "One or more of the following prerequisites was not found:"
+  echo "gfortran $GCC_VER, gcc $GCC_VER, g++ $GCC_VER, pkg-config, realpath, make"
+  echo ""
+  echo "Press 'Enter' to choose the square-bracketed default answers:"
+  echo "[Y] denotes 'Yes.'"
+
+  printf "Is it ok to to install the missing prerequisites using Homebrew? [Y]"
+  read answer
+  if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
+    echo "Installation declined."
+    echo "Please ensure that the listed prerequisites are installed and in your PATH and then rerun './install.sh'."
+    echo "To use compilers other than gcc-$GCC_VER,g++-$GCC_VER, and gfortran-$GCC_VER," 
+    echo "please also set the FC, CC, and CXX environment variables."
+    echo "Caffeine was not installed." 
     exit 1
   fi
 
-  if ! command -v brew > /dev/null ; then
+  if command -v brew > /dev/null; then
+    BREW_COMMAND="brew"
+  else
+    if ! command -v curl > /dev/null 2>&1; then
+      echo "No download mechanism found. Please install curl and rerun ./install.sh"
+      exit 1
+    fi
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     BREW_COMMAND=/home/linuxbrew/.linuxbrew/bin/brew
-  else
-    BREW_COMMAND="brew"
   fi
   "$BREW_COMMAND" install pkg-config coreutils gcc@$GCC_VER
-fi
-export CC=`which gcc-$GCC_VER`
-export CXX=`which g++-$GCC_VER`
-export FC=`which gfortran-$GCC_VER`
-
-PREFIX=`realpath $PREFIX`
-
-GASNET_TAR_FILE="GASNet-stable.tar.gz"
-GASNET_SOURCE_URL="https://bitbucket.org/berkeleylab/gasnet/downloads/$GASNET_TAR_FILE"
-DEPENDENCIES_DIR="build/dependencies"
-if [ ! -d $DEPENDENCIES_DIR ]; then
-  mkdir -pv $DEPENDENCIES_DIR
+  CC=`which gcc-$GCC_VER`
+  CXX=`which g++-$GCC_VER`
+  FC=`which gfortran-$GCC_VER`
+  PREFIX=`realpath $PREFIX`
 fi
 
-cd $DEPENDENCIES_DIR
+export FPM_FC="$FC"
+export FPM_CC="$CC"
+FPM_SOURCE_URL="https://github.com/fortran-lang/fpm/archive/refs/tags/v$FPM_VERSION.tar.gz"
 
-  if [ ! -f $GASNET_TAR_FILE ]; then
-    curl -L $GASNET_SOURCE_URL > $GASNET_TAR_FILE
+if [ ! -d build/dependencies ]; then
+  mkdir -p build/dependencies
+fi
+
+if command -v fpm > /dev/null 2>&1; then
+  FPM="fpm"
+else
+  echo "Fortran Package Manager (fpm) not found."
+  printf "Is it ok to to downloand and install fpm? [yes] ('Enter' for square-bracketed default.)"
+  read answer
+  if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
+    echo "Installation declined."
+    echo "Please ensure fpm $FPM_VERSION or greater is in your PATH and then rerun './install.sh'."
+    echo "Caffeine not installed."
+    exit 1
+  fi
+  curl -L $FPM_SOURCE_URL | tar xvz -C build/dependencies/
+  (cd build/dependencies/fpm-$FPM_VERSION && ./install.sh --prefix="$PREFIX")
+fi
+
+export PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
+pkg="gasnet-smp-seq"
+if [ ! -f "$PKG_CONFIG_PATH/$pkg.pc" ]; then
+  echo "GASNet-EX $pkg.pc file not found in $PKG_CONFIG_PATH."
+
+  echo "Press 'Enter' to choose the square-bracketed default answers:"
+  echo "[Y] denotes 'Yes.'"
+  printf "Is it ok to to download and install GASNet-EX? [Y]"
+  read answer
+  if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
+    echo "Installation declined."
+    echo "Please ensure the $pkg.pc file is in $PKG_CONFIG_PATH and then rerun './install.sh'."
+    echo "Caffeine was not installed."
   fi
 
-  if [ ! -d GASNet-stable ]; then
-    tar xf $GASNET_TAR_FILE
+  GASNET_TAR_FILE="GASNet-stable.tar.gz"
+  GASNET_SOURCE_URL="https://bitbucket.org/berkeleylab/gasnet/downloads/$GASNET_TAR_FILE"
+  DEPENDENCIES_DIR="build/dependencies"
+  if [ ! -d $DEPENDENCIES_DIR ]; then
+    mkdir -pv $DEPENDENCIES_DIR
   fi
-
-  if [ ! -d gasnet ]; then
-    mkdir -v gasnet
-    cd gasnet
+  
+  curl -L $GASNET_SOURCE_URL | tar xvz - -C $DEPENDENCIES_DIR
+  
+  if [ -d $DEPENDENCIES_DIR/GASNet-stable ]; then
+    cd $DEPENDENCIES_DIR/GASNet-stable
       ../GASNet-stable/configure --prefix "$PREFIX"
       make -j 8 all
       make check
       make install
-    cd ..
+    cd -
   fi
-cd ../..
-
-export PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
-pkg="gasnet-smp-seq"
+fi
 
 GASNET_LDFLAGS="`pkg-config $pkg --variable=GASNET_LDFLAGS`"
 GASNET_LIBS="`pkg-config $pkg --variable=GASNET_LIBS`"
@@ -103,7 +191,7 @@ GASNET_CFLAGS="`pkg-config $pkg --variable=GASNET_CFLAGS`"
 GASNET_CPPFLAGS="`pkg-config $pkg --variable=GASNET_CPPFLAGS`"
 
 echo "# DO NOT EDIT OR COMMIT -- Created by caffeine/install.sh" > build/fpm.toml
-cat manifest/fpm.toml.template >> build/fpm.toml
+cp manifest/fpm.toml.template build/fpm.toml
 GASNET_LIB_LOCATIONS=`echo $GASNET_LIBS | awk '{locs=""; for(i = 1; i <= NF; i++) if ($i ~ /^-L/) {locs=(locs " " $i);}; print locs; }'`
 GASNET_LIB_NAMES=`echo $GASNET_LIBS | awk '{names=""; for(i = 1; i <= NF; i++) if ($i ~ /^-l/) {names=(names " " $i);}; print names; }' | sed 's/-l//g'`
 FPM_TOML_LINK_ENTRY="link = [\"$(echo ${GASNET_LIB_NAMES} | sed 's/ /", "/g')\"]"
@@ -115,8 +203,8 @@ cd "$PKG_CONFIG_PATH"
   echo "CAFFEINE_FPM_CC=$GASNET_CC"                                 >> caffeine.pc
   echo "CAFFEINE_FPM_CFLAGS=$GASNET_CFLAGS $GASNET_CPPFLAGS"        >> caffeine.pc
   echo "Name: caffeine"                                             >> caffeine.pc
-  echo "Description: coarray fortran parallel runtime library"      >> caffeine.pc
-  echo "URL: https://gitlab.lbl.gov/rouson/caffeine"                >> caffeine.pc
+  echo "Description: Coarray Fortran parallel runtime library"      >> caffeine.pc
+  echo "URL: https://gitlab.lbl.gov/berkeleylab/caffeine"           >> caffeine.pc
   echo "Version: 0.1.0"                                             >> caffeine.pc
 cd -
 
@@ -129,16 +217,6 @@ cd build
   echo "--link-flag \"`pkg-config caffeine --variable=CAFFEINE_FPM_LDFLAGS`\"" >> run-fpm.sh
   chmod u+x run-fpm.sh
 cd -
-
-
-export FPM_FC="$FC"
-export FPM_CC="$CC"
-if [ ! -d build/dependencies/fpm ]; then
-  git clone https://github.com/fortran-lang/fpm build/dependencies/fpm
-  cd build/dependencies/fpm
-    ./install.sh --prefix="$PREFIX"
-  cd -
-fi
 
 ./build/run-fpm.sh build
 

--- a/install.sh
+++ b/install.sh
@@ -70,13 +70,13 @@ echo "Using pkg-config prefix $PKG_CONFIG_PATH"
 
 if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
   if command -v gfortran-$GCC_VER > /dev/null 2>&1; then
-    FC=gfortran-$GCC_VER
+    FC=`which gfortran-$GCC_VER`
   fi
   if command -v gcc-$GCC_VER > /dev/null 2>&1; then
-    CC=gcc-$GCC_VER
+    CC=`which gcc-$GCC_VER`
   fi
   if command -v g++-$GCC_VER > /dev/null 2>&1; then
-    CXX=g++-$GCC_VER
+    CXX=`which g++-$GCC_VER`
   fi
 fi
 
@@ -93,7 +93,7 @@ if command -v make > /dev/null 2>&1; then
 fi
 
 if command -v fpm > /dev/null 2>&1; then
-  FPM=fpm
+  FPM=`which fpm`
 fi
 
 ask_homebrew_permission()
@@ -248,7 +248,8 @@ echo "${FPM_TOML_LINK_ENTRY}" >> build/fpm.toml
 ln -f -s build/fpm.toml
 
 cd "$PKG_CONFIG_PATH"
-  echo "CAFFEINE_FPM_LDFLAGS=$GASNET_LDFLAGS $GASNET_LIB_LOCATIONS" >  caffeine.pc
+  echo "CAFFEINE_FC=$FC"                                            >  caffeine.pc
+  echo "CAFFEINE_FPM_LDFLAGS=$GASNET_LDFLAGS $GASNET_LIB_LOCATIONS" >> caffeine.pc
   echo "CAFFEINE_FPM_CC=$GASNET_CC"                                 >> caffeine.pc
   echo "CAFFEINE_FPM_CFLAGS=$GASNET_CFLAGS $GASNET_CPPFLAGS"        >> caffeine.pc
   echo "Name: caffeine"                                             >> caffeine.pc
@@ -260,7 +261,8 @@ cd -
 cd build
   echo "#!/bin/sh"                                                             >  run-fpm.sh
   echo "#-- DO NOT EDIT -- created by caffeine/install.sh"                     >> run-fpm.sh
-  echo "\"${FPM}\" \$@ \\"                                             >> run-fpm.sh
+  echo "\"${FPM}\" \$@ \\"                                                     >> run-fpm.sh
+  echo "--compiler \"`pkg-config caffeine --variable=CAFFEINE_FC`\"       \\"  >> run-fpm.sh
   echo "--c-compiler \"`pkg-config caffeine --variable=CAFFEINE_FPM_CC`\" \\"  >> run-fpm.sh
   echo "--c-flag \"`pkg-config caffeine --variable=CAFFEINE_FPM_CFLAGS`\" \\"  >> run-fpm.sh
   echo "--link-flag \"`pkg-config caffeine --variable=CAFFEINE_FPM_LDFLAGS`\"" >> run-fpm.sh

--- a/install.sh
+++ b/install.sh
@@ -64,12 +64,15 @@ set -u # error on use of undefined variable
 if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
   if command -v gfortran-$GCC_VER > /dev/null 2>&1; then
     FC=`which gfortran-$GCC_VER`
+    echo "Setting FC=$FC"
   fi
   if command -v gcc-$GCC_VER > /dev/null 2>&1; then
     CC=`which gcc-$GCC_VER`
+    echo "Setting CC=$CC"
   fi
   if command -v g++-$GCC_VER > /dev/null 2>&1; then
     CXX=`which g++-$GCC_VER`
+    echo "Setting CXX=$CXX"
   fi
 fi
 
@@ -121,10 +124,10 @@ ask_permission_to_install_homebrew_package()
 }
 
 PREFIX=${PREFIX:-"$HOME/.local"}
-echo "Using installation prefix $PREFIX"
+echo "Setting PREFIX=$PREFIX"
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-"$PREFIX/lib/pkgconfig"}
-echo "Using pkg-config prefix $PKG_CONFIG_PATH"
+echo "Setting PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
 
 exit_if_user_declines()
 {

--- a/install.sh
+++ b/install.sh
@@ -283,8 +283,8 @@ echo "${FPM_TOML_LINK_ENTRY}" >> build/fpm.toml
 ln -f -s build/fpm.toml
 
 cd "$PKG_CONFIG_PATH"
-  echo "CAFFEINE_FPM_LDFLAGS=$GASNET_LDFLAGS $GASNET_LIB_LOCATIONS" >> caffeine.pc
-  echo "CAFFEINE_FPM_FC=$FC"                                            >  caffeine.pc
+  echo "CAFFEINE_FPM_LDFLAGS=$GASNET_LDFLAGS $GASNET_LIB_LOCATIONS" >  caffeine.pc
+  echo "CAFFEINE_FPM_FC=$FC"                                        >> caffeine.pc
   echo "CAFFEINE_FPM_CC=$GASNET_CC"                                 >> caffeine.pc
   echo "CAFFEINE_FPM_CFLAGS=$GASNET_CFLAGS $GASNET_CPPFLAGS"        >> caffeine.pc
   echo "Name: caffeine"                                             >> caffeine.pc
@@ -292,6 +292,10 @@ cd "$PKG_CONFIG_PATH"
   echo "URL: https://gitlab.lbl.gov/berkeleylab/caffeine"           >> caffeine.pc
   echo "Version: 0.1.0"                                             >> caffeine.pc
 cd -
+if [ ! -f "$PKG_CONFIG_PATH/caffeine.pc" ]; then
+  echo "Creation of $PKG_CONFIG_PATH/caffeine.pc unsuccessful."
+  exit 1
+fi
 
 cd build
   echo "#!/bin/sh"                                                              >  run-fpm.sh

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -e # exit on error
 
-usage()
+print_usage_info()
 {
     echo "Caffeine Installation Script"
     echo ""
@@ -18,34 +18,34 @@ usage()
 
 GCC_VER=11
 FPM_VERSION="0.5.0"
+GASNET_VERSION="2021.9.0"
 
-prerequisites()
+list_prerequisites()
 {
     echo "Caffeine and this installer were developed with the following prerequisite package" 
     echo "versions, which also indicate the versions that the installer will install if"
     echo "missing and if granted permission:"
     echo ""
     echo "  GCC $GCC_VER"
-    echo "  GASNet-EX 2021.9.1 (gex-stable-2022_01_11-0-g66a0eaf) s"
+    echo "  GASNet-EX $GASNET_VERSION"
     echo "  fpm $FPM_VERSION"
     echo "  pkg-config 0.29.2"
     echo "  realpath 9.0 (Homebrew coreutils 9.0)"
-    echo "  GNU Make 3.1"
+    echo "  GNU Make 3.1 (Homebrew coreutils 9.0)"
     echo ""
     echo "In some cases, earlier versions might also work."
 }
-
 
 while [ "$1" != "" ]; do
     PARAM=$(echo "$1" | awk -F= '{print $1}')
     VALUE=$(echo "$1" | awk -F= '{print $2}')
     case $PARAM in
         -h | --help)
-            usage
+            print_usage_info
             exit
             ;;
         --prereqs)
-            prerequisites
+            list_prerequisites
             exit
             ;;
         --prefix)
@@ -64,6 +64,7 @@ set -u # error on use of undefined variable
 
 if [ -z ${PREFIX+x} ] ; then
   PREFIX="$HOME/.local"
+  echo ""
   echo "Using default installation prefix: $PREFIX"
 fi
 
@@ -91,24 +92,50 @@ if command -v make > /dev/null 2>&1; then
   MAKE=make
 fi
 
-if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
+ask_homebrew_permission()
+{
   echo ""
-  echo "One or more of the following prerequisites was not found:"
-  echo "gfortran $GCC_VER, gcc $GCC_VER, g++ $GCC_VER, pkg-config, realpath, make"
+  echo "Either one or more of the environment variables FC, CC, and CXX are unset or"
+  echo "one or more of the following packages are not in the PATH: pkg-config, realpath, make."
+  echo "If you grant permission to install prerequisites, you will be prompted before each installation." 
   echo ""
-  echo "Press 'Enter' to choose the square-bracketed default answers:"
-  echo "[Y] denotes 'Yes.'"
+  echo "Press 'Enter' to choose the square-bracketed default answer:"
+  printf "Is it ok to use Homebrew to install prerequisite packages? [yes] "
+}
 
-  printf "Is it ok to to install the missing prerequisites using Homebrew? [Y]"
+ask_homebrew_package_permission()
+{
+  echo ""
+  case $1 in  
+    *gcc*) echo "To use pre-installed compilers, set the FC, CC, and CXX environment variables and rerun './install.sh'." ;;
+  esac
+  if [ ! -z ${2+x} ]; then
+    echo "Homebrew installs $1 collectively in one package named '$2'."
+  fi
+  echo ""
+  printf "Is it ok to use Homebrew to install $1? [yes] "
+}
+
+exit_if_user_declines()
+{
   read answer
   if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
     echo "Installation declined."
     echo "Please ensure that the listed prerequisites are installed and in your PATH and then rerun './install.sh'."
-    echo "To use compilers other than gcc-$GCC_VER,g++-$GCC_VER, and gfortran-$GCC_VER," 
+    case ${1:-} in  
+      *GCC*) echo "To use pre-installed compilers, set the FC, CC, and CXX environment variables and rerun './install.sh'." ;;
+    esac
+    echo "To use compilers other than gcc-$GCC_VER, g++-$GCC_VER, and gfortran-$GCC_VER," 
     echo "please also set the FC, CC, and CXX environment variables."
     echo "Caffeine was not installed." 
     exit 1
   fi
+}
+
+if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
+
+  ask_homebrew_permission 
+  exit_if_user_declines
 
   if command -v brew > /dev/null; then
     BREW_COMMAND="brew"
@@ -122,7 +149,23 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
       BREW_COMMAND=/home/linuxbrew/.linuxbrew/bin/brew
     fi
   fi
-  "$BREW_COMMAND" install pkg-config coreutils gcc@$GCC_VER
+
+  if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
+    ask_homebrew_package_permission "gfortran, gcc, and g++" "gcc@$GCC_VER" 
+    exit_if_user_declines "GCC"
+    "$BREW_COMMAND" install gcc@$GCC_VER
+  fi
+  if [ -z ${PKG_CONFIG+x} ]; then
+    ask_homebrew_package_permission "pkg-config"
+    exit_if_user_declines 
+    "$BREW_COMMAND" install pkg-config
+  fi
+  if [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
+    ask_homebrew_package_permission "realpath and make" "coreutils"
+    exit_if_user_declines 
+    "$BREW_COMMAND" install coreutils
+  fi
+
   CC=`which gcc-$GCC_VER`
   CXX=`which g++-$GCC_VER`
   FC=`which gfortran-$GCC_VER`
@@ -137,18 +180,20 @@ if [ ! -d build/dependencies ]; then
   mkdir -p build/dependencies
 fi
 
+ask_package_permission()
+{
+  echo ""
+  echo "$1 not found."
+  echo ""
+  echo "Press 'Enter' for the square-bracketed default answer:"
+  printf "Is it ok to download and install $1? [yes] "
+}
+
 if command -v fpm > /dev/null 2>&1; then
   FPM="fpm"
 else
-  echo "Fortran Package Manager (fpm) not found."
-  printf "Is it ok to to downloand and install fpm? [yes] ('Enter' for square-bracketed default.)"
-  read answer
-  if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
-    echo "Installation declined."
-    echo "Please ensure fpm $FPM_VERSION or greater is in your PATH and then rerun './install.sh'."
-    echo "Caffeine not installed."
-    exit 1
-  fi
+  ask_package_permission "fpm"
+  exit_if_user_declines
   curl -L $FPM_SOURCE_URL | tar xvz -C build/dependencies/
   (cd build/dependencies/fpm-$FPM_VERSION && ./install.sh --prefix="$PREFIX")
 fi
@@ -156,11 +201,11 @@ fi
 export PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
 pkg="gasnet-smp-seq"
 if [ ! -f "$PKG_CONFIG_PATH/$pkg.pc" ]; then
+  echo ""
   echo "GASNet-EX $pkg.pc file not found in $PKG_CONFIG_PATH."
-
-  echo "Press 'Enter' to choose the square-bracketed default answers:"
-  echo "[Y] denotes 'Yes.'"
-  printf "Is it ok to to download and install GASNet-EX? [Y]"
+  echo ""
+  echo "Press 'Enter' for the square-bracketed default answer:"
+  printf "Is it ok to download and install GASNet-EX? [yes] "
   read answer
   if [ -n "$answer" -a "$answer" != "y" -a "$answer" != "Y" -a "$answer" != "Yes" -a "$answer" != "YES" -a "$answer" != "yes" ]; then
     echo "Installation declined."
@@ -168,8 +213,8 @@ if [ ! -f "$PKG_CONFIG_PATH/$pkg.pc" ]; then
     echo "Caffeine was not installed."
   fi
 
-  GASNET_TAR_FILE="GASNet-stable.tar.gz"
-  GASNET_SOURCE_URL="https://bitbucket.org/berkeleylab/gasnet/downloads/$GASNET_TAR_FILE"
+  GASNET_TAR_FILE="GASNet-$GASNET_VERSION.tar.gz"
+  GASNET_SOURCE_URL="https://gasnet.lbl.gov/EX/GASNet-$GASNET_VERSION.tar.gz"
   DEPENDENCIES_DIR="build/dependencies"
   if [ ! -d $DEPENDENCIES_DIR ]; then
     mkdir -pv $DEPENDENCIES_DIR
@@ -177,9 +222,9 @@ if [ ! -f "$PKG_CONFIG_PATH/$pkg.pc" ]; then
   
   curl -L $GASNET_SOURCE_URL | tar xvz - -C $DEPENDENCIES_DIR
   
-  if [ -d $DEPENDENCIES_DIR/GASNet-stable ]; then
-    cd $DEPENDENCIES_DIR/GASNet-stable
-      ../GASNet-stable/configure --prefix "$PREFIX"
+  if [ -d $DEPENDENCIES_DIR/GASNet-$GASNET_VERSION ]; then
+    cd $DEPENDENCIES_DIR/GASNet-$GASNET_VERSION
+      FC="$FC" CC="$CC" CXX="$CXX" ../GASNet-$GASNET_VERSION/configure --prefix "$PREFIX"
       make -j 8 all
       make check
       make install

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ print_usage_info()
     echo ""
 }
 
-GCC_VER=11
+GCC_VERSION=11
 GASNET_VERSION="2021.9.0"
 
 list_prerequisites()
@@ -25,7 +25,7 @@ list_prerequisites()
     echo "versions, which also indicate the versions that the installer will install if"
     echo "missing and if granted permission:"
     echo ""
-    echo "  GCC $GCC_VER"
+    echo "  GCC $GCC_VERSION"
     echo "  GASNet-EX $GASNET_VERSION"
     echo "  fpm 0.5.0"
     echo "  pkg-config 0.29.2"
@@ -62,16 +62,16 @@ done
 set -u # error on use of undefined variable
 
 if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
-  if command -v gfortran-$GCC_VER > /dev/null 2>&1; then
-    FC=`which gfortran-$GCC_VER`
+  if command -v gfortran-$GCC_VERSION > /dev/null 2>&1; then
+    FC=`which gfortran-$GCC_VERSION`
     echo "Setting FC=$FC"
   fi
-  if command -v gcc-$GCC_VER > /dev/null 2>&1; then
-    CC=`which gcc-$GCC_VER`
+  if command -v gcc-$GCC_VERSION > /dev/null 2>&1; then
+    CC=`which gcc-$GCC_VERSION`
     echo "Setting CC=$CC"
   fi
-  if command -v g++-$GCC_VER > /dev/null 2>&1; then
-    CXX=`which g++-$GCC_VER`
+  if command -v g++-$GCC_VERSION > /dev/null 2>&1; then
+    CXX=`which g++-$GCC_VERSION`
     echo "Setting CXX=$CXX"
   fi
 fi
@@ -132,7 +132,7 @@ exit_if_user_declines()
       *GASNet*) 
         echo "Please ensure the $pkg.pc file is in $PKG_CONFIG_PATH and then rerun './install.sh'." ;;
       *GCC*) 
-        echo "To use compilers other than Homebrew-installed gcc-$GCC_VER, g++-$GCC_VER, and gfortran-$GCC_VER,"
+        echo "To use compilers other than Homebrew-installed gcc-$GCC_VERSION, g++-$GCC_VERSION, and gfortran-$GCC_VERSION,"
         echo "please set the FC, CC, and CXX environment variables and rerun './install.sh'." ;;
       *) 
         echo "Please ensure that $1 is installed and in your PATH and then rerun './install.sh'." ;;
@@ -150,11 +150,11 @@ fi
 if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] || [ -z ${FPM+x} ] ; then
 
   ask_permission_to_use_homebrew 
-  exit_if_user_declines
+  exit_if_user_declines "brew"
 
-  BREW_COMMAND="brew"
+  BREW="brew"
 
-  if ! command -v brew > /dev/null 2>&1; then
+  if ! command -v $BREW > /dev/null 2>&1; then
 
     ask_permission_to_install_homebrew
     exit_if_user_declines "brew"
@@ -181,49 +181,45 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
     fi
 
     if [ $(uname) = "Linux" ]; then
-      BREW_COMMAND=/home/linuxbrew/.linuxbrew/bin/brew
-      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      BREW=/home/linuxbrew/.linuxbrew/bin/brew
+      eval "$($BREW shellenv)"
     fi
   fi
 
   if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ]; then
-    ask_permission_to_install_homebrew_package "gfortran, gcc, and g++" "gcc@$GCC_VER" 
+    ask_permission_to_install_homebrew_package "gfortran, gcc, and g++" "gcc@$GCC_VERSION" 
     exit_if_user_declines "GCC"
-    "$BREW_COMMAND" install gcc@$GCC_VER
+    "$BREW" install gcc@$GCC_VERSION
   fi
-  CC=`which gcc-$GCC_VER`
-  CXX=`which g++-$GCC_VER`
-  FC=`which gfortran-$GCC_VER`
+  CC=`which gcc-$GCC_VERSION`
+  CXX=`which g++-$GCC_VERSION`
+  FC=`which gfortran-$GCC_VERSION`
 
 
   if [ -z ${PKG_CONFIG+x} ]; then
     ask_permission_to_install_homebrew_package "'pkg-config'"
     exit_if_user_declines "pkg-config"
-    "$BREW_COMMAND" install pkg-config
+    "$BREW" install pkg-config
   fi
-
   PKG_CONFIG=`which pkg-config`
 
   if [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
     ask_permission_to_install_homebrew_package "'realpath' and 'make'" "coreutils"
     exit_if_user_declines "realpath"
-    "$BREW_COMMAND" install coreutils
+    "$BREW" install coreutils
   fi
   REALPATH=`which realpath`
 
   if [ -z ${FPM+x} ] ; then
     ask_permission_to_install_homebrew_package "'fpm'"
     exit_if_user_declines "fpm"
-    "$BREW_COMMAND" tap awvwgk/fpm
-    "$BREW_COMMAND" install fpm
+    "$BREW" tap awvwgk/fpm
+    "$BREW" install fpm
   fi
   FPM=`which fpm`
 fi
 
-if [ -z "${PREFIX+x}" ]; then
-  PREFIX="$HOME/.local"
-fi
-PREFIX=`$REALPATH $PREFIX`
+PREFIX=`$REALPATH ${PREFIX:-"${HOME}/.local"}`
 echo "PREFIX=$PREFIX"
 
 if [ -z ${PKG_CONFIG_PATH+x} ]; then
@@ -274,7 +270,7 @@ exit_if_pkg_config_pc_file_missing()
   if ! $PKG_CONFIG $1 ; then
     echo "$1.pc pkg-config file not found"
     exit 1
-fi
+  fi
 }
 
 exit_if_pkg_config_pc_file_missing "$pkg"
@@ -295,7 +291,7 @@ ln -f -s build/fpm.toml
 
 CAFFEINE_PC="$PREFIX/lib/pkgconfig/caffeine.pc"
 echo "CAFFEINE_FPM_LDFLAGS=$GASNET_LDFLAGS $GASNET_LIB_LOCATIONS" >  $CAFFEINE_PC
-echo "CAFFEINE_FPM_FC=$FC"                                        >> $CAFFEINE_PC
+echo "CAFFEINE_FPM_FC=$FPM_FC"                                    >> $CAFFEINE_PC
 echo "CAFFEINE_FPM_CC=$GASNET_CC"                                 >> $CAFFEINE_PC
 echo "CAFFEINE_FPM_CFLAGS=$GASNET_CFLAGS $GASNET_CPPFLAGS"        >> $CAFFEINE_PC
 echo "Name: caffeine"                                             >> $CAFFEINE_PC


### PR DESCRIPTION
This PR replaces #1 and addresses several [PR comments] and [issue comments] made on a predecessor fork about the Caffeine installer.  The PR enhances the installer to

1. Replace `#!/bin/dash` with the more portable `#!/bin/sh`.
2. Always ask for permission before installing a package,
3. Produce output that explains which packages will be installed if permission is granted,
4. Ask permission to install and use Homebrew for package installation if any Homebrew-installable packages are missing, and
5. Disaggregate prerequisites where possible\*.

On my machine, this PR completes without error 
- [X] On a bare macOS system without Homebrew pre-installed and with no prerequisites pre-installed.  
- [X] On macOS with all prerequisites installed.
- [X] Inside a Lubuntu Linux virtual machine without Homebrew pre-installed and with no prerequisites pre-installed.
- [X] Inside a Lubuntu Linux virtual machine with all prerequisites installed.


\* Because some Homebrew packages contain more than one prerequisite that cannot be installed independently of each other, there will be some cases in which an already installed prerequisite will nonetheless be installed via Homebrew.  For example, if any of the environment variables `FC`, `CC`, and `CXX` is unset and any of the Homebrew `gcc-11`, `g++-11`,  and `gfortran-11` is not in the `PATH`, then the script will excecute `brew install gcc@11` if granted permission and this will result in the installation of all three compilers:  `gcc-11`, `g++-11`,  and `gfortran-11`.

[PR comments]: https://github.com/rouson/caffeine/pull/15
[issue comments]: https://github.com/rouson/caffeine/issues/14