### PR TITLE
Fix fpm-run.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -306,7 +306,7 @@ exit_if_pkg_config_pc_file_missing "caffeine"
 RUN_FPM_SH="build/run-fpm.sh"
 echo "#!/bin/sh"                                                              >  $RUN_FPM_SH
 echo "#-- DO NOT EDIT -- created by caffeine/install.sh"                      >> $RUN_FPM_SH
-echo "\"${FPM}\" \$@ \\"                                                      >> $RUN_FPM_SH
+echo "\"${FPM}\" \"\$@\" \\"                                                      >> $RUN_FPM_SH
 echo "--compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`\"   \\"  >> $RUN_FPM_SH
 echo "--c-compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`\" \\"  >> $RUN_FPM_SH
 echo "--c-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`\" \\"  >> $RUN_FPM_SH

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -3,10 +3,7 @@
 
 #include <gasnetex.h>
 #include <stdio.h>
-
-#ifndef _GASNET_SAFE_
 #include "gasnet_safe.h"
-#endif
 
 gex_Client_t myclient;
 gex_EP_t myep;

--- a/src/caffeine/gasnet_safe.h
+++ b/src/caffeine/gasnet_safe.h
@@ -1,8 +1,9 @@
 // Copyright (c), The Regents of the University of California
 // Terms of use are as specified in LICENSE.txt
 
-#include <gasnetex.h>
+#ifndef _GASNET_SAFE_
 #define _GASNET_SAFE_
+#include <gasnetex.h>
 
 /* Macro to check return codes and terminate with useful message. */
 #define GASNET_SAFE(fncall) do {                                     \
@@ -17,3 +18,4 @@
       gasnet_exit(_retval);                                          \
     }                                                                \
   } while(0)
+#endif

--- a/test/caf_co_sum_test.f90
+++ b/test/caf_co_sum_test.f90
@@ -1,0 +1,28 @@
+module caf_co_sum_test
+    use caffeine_m, only : caf_co_sum, caf_num_images
+    use vegetables, only: result_t, test_item_t, assert_equals, describe, it
+
+    implicit none
+    private
+    public :: test_caf_co_sum
+
+contains
+    function test_caf_co_sum() result(tests)
+        type(test_item_t) tests
+    
+        tests = describe( &
+          "The caf_co_sum subroutine", &
+          [ it("sums scalars with result_image not present", sum_scalars_no_result_image) &
+        ])
+    end function
+
+    function sum_scalars_no_result_image() result(result_)
+        type(result_t) result_
+        integer i
+ 
+        i = 1
+        call caf_co_sum(i)
+        result_ = assert_equals(caf_num_images(), i)
+    end function
+
+end module caf_co_sum_test

--- a/test/main.f90
+++ b/test/main.f90
@@ -7,6 +7,8 @@ contains
     subroutine run()
         use a00_caffeinate_test, only: &
                 a00_caffeinate_caffeinate => test_caffeinate
+        use caf_co_sum_test, only: &
+                caf_co_sum_caf_co_sum => test_caf_co_sum
         use caf_error_stop_test, only: &
                 caf_error_stop_caf_this_image => test_caf_this_image
         use caf_num_images_test, only: &
@@ -18,13 +20,14 @@ contains
         use vegetables, only: test_item_t, test_that, run_tests
 
         type(test_item_t) :: tests
-        type(test_item_t) :: individual_tests(5)
+        type(test_item_t) :: individual_tests(6)
 
         individual_tests(1) = a00_caffeinate_caffeinate()
-        individual_tests(2) = caf_error_stop_caf_this_image()
-        individual_tests(3) = caf_num_images_caf_num_images()
-        individual_tests(4) = caf_this_image_caf_this_image()
-        individual_tests(5) = zzz_decaffeinate_decaffeinate()
+        individual_tests(2) = caf_co_sum_caf_co_sum()
+        individual_tests(3) = caf_error_stop_caf_this_image()
+        individual_tests(4) = caf_num_images_caf_num_images()
+        individual_tests(5) = caf_this_image_caf_this_image()
+        individual_tests(6) = zzz_decaffeinate_decaffeinate()
         tests = test_that(individual_tests)
 
         call run_tests(tests)


### PR DESCRIPTION
This PR adds required double-quotes in the `fpm` argument in the generated `run-fpm.sh` script.