### PR TITLE
Add co_sum support for all valid types & ranks

### DIFF
--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -53,7 +53,6 @@ void c_sync_all()
   gasnet_barrier_notify(0,GASNET_BARRIERFLAG_ANONYMOUS);
   gasnet_barrier_wait(0,GASNET_BARRIERFLAG_ANONYMOUS);
 }
-
 void c_co_sum_no_result_image_int32(void* c_loc_a, size_t Nelem)
 {
       gex_Event_t ev
@@ -79,5 +78,61 @@ void c_co_sum_no_result_image_double(void* c_loc_a, size_t Nelem)
 {
       gex_Event_t ev
         = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_DBL, sizeof(double), Nelem, GEX_OP_ADD, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_min_no_result_image_int32(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I32, sizeof(int32_t), Nelem, GEX_OP_MIN, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_min_no_result_image_int64(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I64, sizeof(int64_t), Nelem, GEX_OP_MIN, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_min_no_result_image_float(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_FLT, sizeof(float), Nelem, GEX_OP_MIN, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_min_no_result_image_double(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_DBL, sizeof(double), Nelem, GEX_OP_MIN, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_max_no_result_image_int32(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I32, sizeof(int32_t), Nelem, GEX_OP_MAX, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_max_no_result_image_int64(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I64, sizeof(int64_t), Nelem, GEX_OP_MAX, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_max_no_result_image_float(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_FLT, sizeof(float), Nelem, GEX_OP_MAX, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_max_no_result_image_double(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_DBL, sizeof(double), Nelem, GEX_OP_MAX, NULL, NULL, 0);
       gex_Event_Wait(ev);  
 }

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -60,9 +60,24 @@ void c_co_sum_no_result_image_int32(void* c_loc_a, size_t Nelem)
         = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I32, sizeof(int32_t), Nelem, GEX_OP_ADD, NULL, NULL, 0);
       gex_Event_Wait(ev);  
 }
+
 void c_co_sum_no_result_image_int64(void* c_loc_a, size_t Nelem)
 {
       gex_Event_t ev
-        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I32, sizeof(int32_t), Nelem, GEX_OP_ADD, NULL, NULL, 0);
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I64, sizeof(int64_t), Nelem, GEX_OP_ADD, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_sum_no_result_image_float(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_FLT, sizeof(float), Nelem, GEX_OP_ADD, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}
+
+void c_co_sum_no_result_image_double(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_DBL, sizeof(double), Nelem, GEX_OP_ADD, NULL, NULL, 0);
       gex_Event_Wait(ev);  
 }

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -60,3 +60,9 @@ void c_co_sum_no_result_image_int32(void* c_loc_a, size_t Nelem)
         = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I32, sizeof(int32_t), Nelem, GEX_OP_ADD, NULL, NULL, 0);
       gex_Event_Wait(ev);  
 }
+void c_co_sum_no_result_image_int64(void* c_loc_a, size_t Nelem)
+{
+      gex_Event_t ev
+        = gex_Coll_ReduceToAllNB(myteam, c_loc_a, c_loc_a, GEX_DT_I32, sizeof(int32_t), Nelem, GEX_OP_ADD, NULL, NULL, 0);
+      gex_Event_Wait(ev);  
+}

--- a/src/caffeine/collective_subroutines/co_broadcast_s.f90
+++ b/src/caffeine/collective_subroutines/co_broadcast_s.f90
@@ -1,0 +1,9 @@
+submodule(collective_subroutines_m)  co_broadcast_s
+
+contains
+
+  module procedure caf_co_broadcast
+    error stop "co_broadcast not yet supported"
+  end procedure
+
+end submodule co_broadcast_s

--- a/src/caffeine/collective_subroutines/co_max_s.f90
+++ b/src/caffeine/collective_subroutines/co_max_s.f90
@@ -1,0 +1,9 @@
+submodule(collective_subroutines_m)  co_max_s
+
+contains
+
+  module procedure caf_co_max
+    error stop "co_max not yet supported"
+  end procedure
+
+end submodule co_max_s

--- a/src/caffeine/collective_subroutines/co_max_s.f90
+++ b/src/caffeine/collective_subroutines/co_max_s.f90
@@ -1,9 +1,82 @@
-submodule(collective_subroutines_m)  co_max_s
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+submodule(collective_subroutines_m) co_max_s
+  use iso_c_binding, only : c_int32_t, c_int64_t, c_ptr, c_size_t, c_loc, c_float, c_double, c_char
+    
+  implicit none
 
-contains
+contains 
 
   module procedure caf_co_max
-    error stop "co_max not yet supported"
+
+   interface
+
+     !! void c_co_max_no_result_image_int32(void* c_loc_a, int Nelem)
+     subroutine c_co_max_no_result_image_int32(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_max_no_result_image_int64(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_max_no_result_image_float(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_max_no_result_image_double(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+    !subroutine c_co_max_no_result_image_char(c_loc_a, Nelem) bind(C)
+    !  import c_ptr, c_size_t
+    !  type(c_ptr), value :: c_loc_a
+    !  integer(c_size_t), value :: Nelem
+    !end subroutine
+
+   end interface
+
+   select rank(a)
+     rank(0) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=1_c_size_t)
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=1_c_size_t)
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=1_c_size_t)
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=1_c_size_t)
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=2_c_size_t)
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(1) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+   end select
+
   end procedure
 
 end submodule co_max_s

--- a/src/caffeine/collective_subroutines/co_min_s.f90
+++ b/src/caffeine/collective_subroutines/co_min_s.f90
@@ -1,9 +1,292 @@
-submodule(collective_subroutines_m)  co_min_s
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+submodule(collective_subroutines_m) co_min_s
+  use iso_c_binding, only : c_int32_t, c_int64_t, c_ptr, c_size_t, c_loc, c_float, c_double, c_char
+    
+  implicit none
 
-contains
+contains 
 
   module procedure caf_co_min
-    error stop "co_min not yet supported"
+
+   interface
+
+     !! void c_co_min_no_result_image_int32(void* c_loc_a, int Nelem)
+     subroutine c_co_min_no_result_image_int32(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_min_no_result_image_int64(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_min_no_result_image_float(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_min_no_result_image_double(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+    !subroutine c_co_min_no_result_image_char(c_loc_a, Nelem) bind(C)
+    !  import c_ptr, c_size_t
+    !  type(c_ptr), value :: c_loc_a
+    !  integer(c_size_t), value :: Nelem
+    !end subroutine
+
+   end interface
+
+   select rank(a)
+     rank(0) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=1_c_size_t)
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=1_c_size_t)
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=1_c_size_t)
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=1_c_size_t)
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=2_c_size_t)
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(1) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(2) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(3) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(4) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(5) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(6) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(7) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(8) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(9) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(10) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(11) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(12) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(13) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(14) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+     rank(15) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_min_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_min_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_min_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_min_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_min_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_min: unsupported type"
+       end select
+   end select
+
   end procedure
 
 end submodule co_min_s

--- a/src/caffeine/collective_subroutines/co_min_s.f90
+++ b/src/caffeine/collective_subroutines/co_min_s.f90
@@ -1,0 +1,9 @@
+submodule(collective_subroutines_m)  co_min_s
+
+contains
+
+  module procedure caf_co_min
+    error stop "co_min not yet supported"
+  end procedure
+
+end submodule co_min_s

--- a/src/caffeine/collective_subroutines/co_reduce_s.f90
+++ b/src/caffeine/collective_subroutines/co_reduce_s.f90
@@ -1,0 +1,9 @@
+submodule(collective_subroutines_m)  co_reduce_s
+
+contains
+
+  module procedure caf_co_reduce
+    error stop "co_reduce not yet supported"
+  end procedure
+
+end submodule co_reduce_s

--- a/src/caffeine/collective_subroutines/co_sum_s.f90
+++ b/src/caffeine/collective_subroutines/co_sum_s.f90
@@ -1,6 +1,6 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
-submodule(collective_subroutines_m) collective_subroutines_s
+submodule(collective_subroutines_m) co_sum_s
   use iso_c_binding, only : c_int32_t, c_int64_t, c_ptr, c_size_t, c_loc, c_float, c_double
     
   implicit none
@@ -315,16 +315,4 @@ contains
 
   end procedure
 
-  module procedure caf_co_max
-  end procedure
-
-  module procedure caf_co_min
-  end procedure
-
-  module procedure caf_co_reduce
-  end procedure
-
-  module procedure caf_co_broadcast
-  end procedure
-
-end submodule collective_subroutines_s
+end submodule co_sum_s

--- a/src/caffeine/collective_subroutines_s.f90
+++ b/src/caffeine/collective_subroutines_s.f90
@@ -66,6 +66,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -78,6 +82,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
@@ -92,6 +100,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -104,6 +116,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
@@ -118,6 +134,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -130,6 +150,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
@@ -144,6 +168,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -156,6 +184,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
@@ -170,6 +202,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -182,6 +218,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
@@ -196,6 +236,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -208,6 +252,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
@@ -222,6 +270,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -235,6 +287,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -247,6 +303,10 @@ contains
          type is(real(c_float))
            call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(complex(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"

--- a/src/caffeine/collective_subroutines_s.f90
+++ b/src/caffeine/collective_subroutines_s.f90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(collective_subroutines_m) collective_subroutines_s
-  use iso_c_binding, only : c_int32_t, c_int64_t, c_ptr, c_size_t, c_loc, c_sizeof
+  use iso_c_binding, only : c_int32_t, c_int64_t, c_ptr, c_size_t, c_loc, c_float, c_double
+    
   implicit none
 
 contains 
@@ -12,13 +13,25 @@ contains
    interface
 
      subroutine c_co_sum_no_result_image_int32(c_loc_a, Nelem) bind(C)
-       import c_int32_t, c_ptr, c_size_t
+       import c_ptr, c_size_t
        type(c_ptr), value :: c_loc_a
        integer(c_size_t), value :: Nelem
      end subroutine
 
      subroutine c_co_sum_no_result_image_int64(c_loc_a, Nelem) bind(C)
-       import c_int32_t, c_ptr, c_size_t
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_sum_no_result_image_float(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
+     subroutine c_co_sum_no_result_image_double(c_loc_a, Nelem) bind(C)
+       import c_ptr, c_size_t
        type(c_ptr), value :: c_loc_a
        integer(c_size_t), value :: Nelem
      end subroutine
@@ -32,6 +45,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=1_c_size_t)
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=1_c_size_t)
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=1_c_size_t)
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=1_c_size_t)
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -41,6 +58,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -50,6 +71,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -59,6 +84,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -68,6 +97,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -77,6 +110,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -86,6 +123,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -95,6 +136,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -104,6 +149,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -113,6 +162,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -122,6 +175,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -131,6 +188,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -140,6 +201,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -149,6 +214,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -158,6 +227,10 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -167,11 +240,13 @@ contains
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
          type is(integer(c_int64_t))
            call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select
-     rank default
-       error stop "caf_co_sum: unsupported rank"
    end select
 
   end procedure

--- a/src/caffeine/collective_subroutines_s.f90
+++ b/src/caffeine/collective_subroutines_s.f90
@@ -1,7 +1,7 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(collective_subroutines_m) collective_subroutines_s
-  use iso_c_binding, only : c_int32_t, c_ptr, c_size_t, c_loc, c_sizeof
+  use iso_c_binding, only : c_int32_t, c_int64_t, c_ptr, c_size_t, c_loc, c_sizeof
   implicit none
 
 contains 
@@ -10,11 +10,19 @@ contains
 
    !! void c_co_sum_no_result_image_int32(void* c_loc_a, int Nelem)
    interface
+
      subroutine c_co_sum_no_result_image_int32(c_loc_a, Nelem) bind(C)
        import c_int32_t, c_ptr, c_size_t
        type(c_ptr), value :: c_loc_a
        integer(c_size_t), value :: Nelem
      end subroutine
+
+     subroutine c_co_sum_no_result_image_int64(c_loc_a, Nelem) bind(C)
+       import c_int32_t, c_ptr, c_size_t
+       type(c_ptr), value :: c_loc_a
+       integer(c_size_t), value :: Nelem
+     end subroutine
+
    end interface
 
    select rank(a)
@@ -22,6 +30,8 @@ contains
        select type(a)
          type is(integer(c_int32_t))
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=1_c_size_t)
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=1_c_size_t)
          class default
            error stop "caf_co_sum: unsupported type"
        end select
@@ -29,6 +39,134 @@ contains
        select type(a)
          type is(integer(c_int32_t))
            call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(2) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(3) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(4) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(5) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(6) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(7) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(8) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(9) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(10) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(11) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(12) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(13) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(14) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_sum: unsupported type"
+       end select
+     rank(15) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_sum_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_sum_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
          class default
            error stop "caf_co_sum: unsupported type"
        end select

--- a/src/caffeine/collective_subroutines_s.f90
+++ b/src/caffeine/collective_subroutines_s.f90
@@ -49,6 +49,10 @@ contains
            call c_co_sum_no_result_image_float(c_loc(a), nelem=1_c_size_t)
          type is(real(c_double))
            call c_co_sum_no_result_image_double(c_loc(a), nelem=1_c_size_t)
+         type is(complex(c_float))
+           call c_co_sum_no_result_image_float(c_loc(a), nelem=2_c_size_t)
+         type is(complex(c_double))
+           call c_co_sum_no_result_image_double(c_loc(a), nelem=2_c_size_t)
          class default
            error stop "caf_co_sum: unsupported type"
        end select

--- a/test/caf_co_min_test.f90
+++ b/test/caf_co_min_test.f90
@@ -1,0 +1,112 @@
+module caf_co_min_test
+    use caffeine_m, only : caf_co_min, caf_num_images
+    use vegetables, only: result_t, test_item_t, assert_equals, describe, it, assert_that, assert_equals
+    use image_enumeration_m, only : caf_this_image, caf_num_images
+
+    implicit none
+    private
+    public :: test_caf_co_min
+
+contains
+    function test_caf_co_min() result(tests)
+        type(test_item_t) tests
+    
+        tests = describe( &
+          "The caf_co_min subroutine computes the minimum", &
+          [ it("default integer scalar without result_image present", min_default_integer_scalars) &
+           ,it("integer(c_int64_t) scalar without result_image present", min_c_int64_scalars) &
+           ,it("default integer 1D array elements without result_image present", min_default_integer_1D_array) &
+           ,it("default integer 7D array elements without result_image present", min_default_integer_7D_array) &
+           ,it("default real scalars without result_image present", min_default_real_scalars) &
+           ,it("double precision 2D array elements (no result_image)", min_double_precision_2D_array) &
+          !,it("character scalar (no result_image)", min_double_precision_2D_array) &
+          !,it("character 2D array elements (no result_image)", min_double_precision_2D_array) &
+        ])
+    end function
+
+    function min_default_integer_scalars() result(result_)
+        type(result_t) result_
+        integer i
+ 
+        i = caf_this_image()
+        call caf_co_min(i)
+        result_ = assert_equals(1, i)
+    end function
+
+    function min_c_int64_scalars() result(result_)
+        use iso_c_binding, only : c_int64_t 
+        type(result_t) result_
+        integer(c_int64_t) i
+ 
+        i = -caf_this_image()
+        call caf_co_min(i)
+        result_ = assert_equals(-caf_num_images(), int(i))
+    end function
+
+    function min_default_integer_1D_array() result(result_)
+        type(result_t) result_
+        integer i
+        integer, allocatable :: array(:)
+ 
+        associate(sequence_ => [(i*caf_this_image(), i=1, caf_num_images())])
+          array = sequence_
+          call caf_co_min(array)
+          associate(min_sequence_ => [(i, i=1, caf_num_images())])
+            result_ = assert_that(all(min_sequence_== array))
+          end associate
+        end associate
+    end function
+
+    function min_default_integer_7D_array() result(result_)
+        type(result_t) result_
+        integer array(2,1,1, 1,1,1, 2)
+ 
+        array = 3 + caf_this_image()
+        call caf_co_min(array)
+        result_ = assert_that(all(array==4))
+    end function
+
+    function min_default_real_scalars() result(result_)
+        type(result_t) result_
+        real scalar
+        real, parameter :: pi = 3.141592654
+
+        scalar = -pi*caf_this_image()
+        call caf_co_min(scalar)
+        result_ = assert_equals(-dble(pi*caf_num_images()), dble(scalar) )
+    end function
+
+    function min_double_precision_2D_array() result(result_)
+        type(result_t) result_
+        double precision, allocatable :: array(:,:)
+        double precision, parameter :: input(*,*) = reshape(-[0,1,2,3,2,1], [3,2])
+ 
+        array = input
+        call caf_co_min(array)
+        result_ = assert_that(all(input==array))
+    end function
+
+   ! function min_default_character_scalars() result(result_)
+   !     type(result_t) result_
+   !     real scalar
+   !     character z
+   !     character, parameter :: i=(0.,1)
+
+   !     z = i
+   !     call caf_co_min(z)
+   !     result_ = assert_equals(dble(abs(i*caf_num_images())), dble(abs(z)) )
+   ! end function
+   !          
+   ! function min_double_precision_character_3D_arrays() result(result_)
+   !     type(result_t) result_
+   !     integer, parameter :: dp = kind(1.D0)
+   !     character(dp), allocatable :: array(:,:,:)
+   !     character(dp), parameter :: &
+   !       input(*,*,*) = reshape( [(-1.,0.) , (0.0,1.0), (1.0,0.0), (0.0,-1.0), (0.0,0.0), (0.0,1.0)], [3,1,2])
+ 
+   !     array = input
+   !     call caf_co_min(array)
+   !     result_ = assert_equals(dble(product(abs(input))*caf_num_images()), dble(product(abs(array))))
+   ! end function
+
+end module caf_co_min_test

--- a/test/caf_co_sum_test.f90
+++ b/test/caf_co_sum_test.f90
@@ -1,6 +1,6 @@
 module caf_co_sum_test
     use caffeine_m, only : caf_co_sum, caf_num_images
-    use vegetables, only: result_t, test_item_t, assert_equals, describe, it
+    use vegetables, only: result_t, test_item_t, assert_equals, describe, it, assert_that
 
     implicit none
     private
@@ -12,17 +12,53 @@ contains
     
         tests = describe( &
           "The caf_co_sum subroutine", &
-          [ it("sums scalars with result_image not present", sum_scalars_no_result_image) &
+          [ it("sums default integer scalars with result_image not present", sum_default_integer_scalars) &
+           ,it("sums integer(c_int64_t) scalars with result_image not present", sum_c_int64_scalars) &
+           ,it("sums default integer 1D array with result_image not present", sum_default_integer_1D_array) &
+           ,it("sums default integer 15D array with result_image not present", sum_default_integer_15D_array) &
         ])
     end function
 
-    function sum_scalars_no_result_image() result(result_)
+    function sum_default_integer_scalars() result(result_)
         type(result_t) result_
         integer i
  
         i = 1
         call caf_co_sum(i)
         result_ = assert_equals(caf_num_images(), i)
+    end function
+
+    function sum_c_int64_scalars() result(result_)
+        use iso_c_binding, only : c_int64_t 
+        type(result_t) result_
+        integer(c_int64_t) i
+        integer i_default_kind
+ 
+        i = 2_c_int64_t
+        call caf_co_sum(i)
+        i_default_kind = i
+        result_ = assert_equals(2*caf_num_images(), i_default_kind)
+    end function
+
+    function sum_default_integer_1D_array() result(result_)
+        type(result_t) result_
+        integer i
+        integer, allocatable :: array(:)
+ 
+        associate(images => caf_num_images(), sequence_ => [(i,i=1,caf_num_images())])
+          array = sequence_
+          call caf_co_sum(array)
+          result_ = assert_that(all(images*sequence_== array))
+        end associate
+    end function
+
+    function sum_default_integer_15D_array() result(result_)
+        type(result_t) result_
+        integer array(2,1,1, 1,1,1, 1,1,1, 1,1,1, 1,2,1)
+ 
+        array = 3
+        call caf_co_sum(array)
+        result_ = assert_that(all(array == 3*caf_num_images()))
     end function
 
 end module caf_co_sum_test

--- a/test/caf_co_sum_test.f90
+++ b/test/caf_co_sum_test.f90
@@ -19,6 +19,7 @@ contains
            ,it("sums default real scalars with result_image not present", sum_default_real_scalars) &
            ,it("sums double precision 2D arrays with result_image not present", sum_double_precision_2D_array) &
            ,it("sums default complex scalars with result_image not present", sum_default_complex_scalars) &
+           ,it("sums double precision 3D complex arrays with result_image not present", sum_double_precision_complex_3D_arrays) &
         ])
     end function
 
@@ -93,6 +94,18 @@ contains
         z = i
         call caf_co_sum(z)
         result_ = assert_equals(dble(abs(i*caf_num_images())), dble(abs(z)) )
+    end function
+             
+    function sum_double_precision_complex_3D_arrays() result(result_)
+        type(result_t) result_
+        integer, parameter :: dp = kind(1.D0)
+        complex(dp), allocatable :: array(:,:,:)
+        complex(dp), parameter :: &
+          input(*,*,*) = reshape( [(-1.,0.) , (0.0,1.0), (1.0,0.0), (0.0,-1.0), (0.0,0.0), (0.0,1.0)], [3,1,2])
+ 
+        array = input
+        call caf_co_sum(array)
+        result_ = assert_equals(dble(product(abs(input))*caf_num_images()), dble(product(abs(array))))
     end function
 
 end module caf_co_sum_test

--- a/test/caf_co_sum_test.f90
+++ b/test/caf_co_sum_test.f90
@@ -1,6 +1,6 @@
 module caf_co_sum_test
     use caffeine_m, only : caf_co_sum, caf_num_images
-    use vegetables, only: result_t, test_item_t, assert_equals, describe, it, assert_that
+    use vegetables, only: result_t, test_item_t, assert_equals, describe, it, assert_that, assert_equals
 
     implicit none
     private
@@ -14,8 +14,10 @@ contains
           "The caf_co_sum subroutine", &
           [ it("sums default integer scalars with result_image not present", sum_default_integer_scalars) &
            ,it("sums integer(c_int64_t) scalars with result_image not present", sum_c_int64_scalars) &
-           ,it("sums default integer 1D array with result_image not present", sum_default_integer_1D_array) &
-           ,it("sums default integer 15D array with result_image not present", sum_default_integer_15D_array) &
+           ,it("sums default integer 1D arrays with result_image not present", sum_default_integer_1D_array) &
+           ,it("sums default integer 15D arrays with result_image not present", sum_default_integer_15D_array) &
+           ,it("sums default real scalars with result_image not present", sum_default_real_scalars) &
+           ,it("sums double precision 2D arrays with result_image not present", sum_double_precision_2D_array) &
         ])
     end function
 
@@ -37,7 +39,7 @@ contains
         i = 2_c_int64_t
         call caf_co_sum(i)
         i_default_kind = i
-        result_ = assert_equals(2*caf_num_images(), i_default_kind)
+        result_ = assert_equals(2*caf_num_images(), int(i))
     end function
 
     function sum_default_integer_1D_array() result(result_)
@@ -58,7 +60,28 @@ contains
  
         array = 3
         call caf_co_sum(array)
-        result_ = assert_that(all(array == 3*caf_num_images()))
+        result_ = assert_that(all(3*caf_num_images() == array))
+    end function
+
+    function sum_default_real_scalars() result(result_)
+        type(result_t) result_
+        real scalar
+        real, parameter :: e = 2.7182818459045
+        integer, parameter :: dp = kind(1.D0)
+
+        scalar = e
+        call caf_co_sum(scalar)
+        result_ = assert_equals(real(caf_num_images()*e, dp), real(scalar, dp) )
+    end function
+
+    function sum_double_precision_2D_array() result(result_)
+        type(result_t) result_
+        double precision, allocatable :: array(:,:)
+        double precision, parameter :: input(*,*) = reshape(-[6,5,4,3,2,1], [3,2])
+ 
+        array = input
+        call caf_co_sum(array)
+        result_ = assert_equals(product(caf_num_images()*input), product(array))
     end function
 
 end module caf_co_sum_test

--- a/test/caf_co_sum_test.f90
+++ b/test/caf_co_sum_test.f90
@@ -18,6 +18,7 @@ contains
            ,it("sums default integer 15D arrays with result_image not present", sum_default_integer_15D_array) &
            ,it("sums default real scalars with result_image not present", sum_default_real_scalars) &
            ,it("sums double precision 2D arrays with result_image not present", sum_double_precision_2D_array) &
+           ,it("sums default complex scalars with result_image not present", sum_default_complex_scalars) &
         ])
     end function
 
@@ -67,11 +68,10 @@ contains
         type(result_t) result_
         real scalar
         real, parameter :: e = 2.7182818459045
-        integer, parameter :: dp = kind(1.D0)
 
         scalar = e
         call caf_co_sum(scalar)
-        result_ = assert_equals(real(caf_num_images()*e, dp), real(scalar, dp) )
+        result_ = assert_equals(dble(caf_num_images()*e), dble(scalar) )
     end function
 
     function sum_double_precision_2D_array() result(result_)
@@ -82,6 +82,17 @@ contains
         array = input
         call caf_co_sum(array)
         result_ = assert_equals(product(caf_num_images()*input), product(array))
+    end function
+
+    function sum_default_complex_scalars() result(result_)
+        type(result_t) result_
+        real scalar
+        complex z
+        complex, parameter :: i=(0.,1)
+
+        z = i
+        call caf_co_sum(z)
+        result_ = assert_equals(dble(abs(i*caf_num_images())), dble(abs(z)) )
     end function
 
 end module caf_co_sum_test

--- a/test/main.f90
+++ b/test/main.f90
@@ -7,6 +7,8 @@ contains
     subroutine run()
         use a00_caffeinate_test, only: &
                 a00_caffeinate_caffeinate => test_caffeinate
+        use caf_co_min_test, only: &
+                caf_co_min_caf_co_min => test_caf_co_min
         use caf_co_sum_test, only: &
                 caf_co_sum_caf_co_sum => test_caf_co_sum
         use caf_error_stop_test, only: &
@@ -20,14 +22,15 @@ contains
         use vegetables, only: test_item_t, test_that, run_tests
 
         type(test_item_t) :: tests
-        type(test_item_t) :: individual_tests(6)
+        type(test_item_t) :: individual_tests(7)
 
         individual_tests(1) = a00_caffeinate_caffeinate()
-        individual_tests(2) = caf_co_sum_caf_co_sum()
-        individual_tests(3) = caf_error_stop_caf_this_image()
-        individual_tests(4) = caf_num_images_caf_num_images()
-        individual_tests(5) = caf_this_image_caf_this_image()
-        individual_tests(6) = zzz_decaffeinate_decaffeinate()
+        individual_tests(2) = caf_co_min_caf_co_min()
+        individual_tests(3) = caf_co_sum_caf_co_sum()
+        individual_tests(4) = caf_error_stop_caf_this_image()
+        individual_tests(5) = caf_num_images_caf_num_images()
+        individual_tests(6) = caf_this_image_caf_this_image()
+        individual_tests(7) = zzz_decaffeinate_decaffeinate()
         tests = test_that(individual_tests)
 
         call run_tests(tests)


### PR DESCRIPTION
With this PR, `caf_co_sum` supports all possible argument types and ranks of the following `kind`:
- [X] default `integer` and `integer(c_int64_t)` arguments of all possible ranks (0-15)
- [X] default `real` and `double precision` arguments of all possible ranks (0-15)
- [X] default and `double precision` `complex` arguments of all possible ranks (0-15)

