### PR TITLE
Add partial support for co_min, co_max

### DIFF
--- a/src/caffeine/collective_subroutines/co_max_s.f90
+++ b/src/caffeine/collective_subroutines/co_max_s.f90
@@ -75,6 +75,216 @@ contains
          class default
            error stop "caf_co_max: unsupported type"
        end select
+     rank(2) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(3) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(4) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(5) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(6) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(7) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(8) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(9) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(10) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(11) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(12) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(13) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(14) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
+     rank(15) 
+       select type(a)
+         type is(integer(c_int32_t))
+           call c_co_max_no_result_image_int32(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(integer(c_int64_t))
+           call c_co_max_no_result_image_int64(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_float))
+           call c_co_max_no_result_image_float(c_loc(a), nelem=size(a,kind=c_size_t))
+         type is(real(c_double))
+           call c_co_max_no_result_image_double(c_loc(a), nelem=size(a,kind=c_size_t))
+        !type is(character(len=*,kind=c_char)(c_float))
+        !  call c_co_max_no_result_image_char(c_loc(a), nelem=size(a,kind=c_size_t))
+         class default
+           error stop "caf_co_max: unsupported type"
+       end select
    end select
 
   end procedure

--- a/test/caf_co_max_test.f90
+++ b/test/caf_co_max_test.f90
@@ -1,0 +1,112 @@
+module caf_co_max_test
+    use caffeine_m, only : caf_co_max, caf_num_images
+    use vegetables, only: result_t, test_item_t, assert_equals, describe, it, assert_that, assert_equals
+    use image_enumeration_m, only : caf_this_image, caf_num_images
+
+    implicit none
+    private
+    public :: test_caf_co_max
+
+contains
+    function test_caf_co_max() result(tests)
+        type(test_item_t) tests
+    
+        tests = describe( &
+          "The caf_co_max subroutine computes the maximum", &
+          [ it("default integer scalar without result_image present", max_default_integer_scalars) &
+           ,it("integer(c_int64_t) scalar without result_image present", max_c_int64_scalars) &
+           ,it("default integer 1D array elements without result_image present", max_default_integer_1D_array) &
+           ,it("default integer 7D array elements without result_image present", max_default_integer_7D_array) &
+           ,it("default real scalars without result_image present", max_default_real_scalars) &
+           ,it("double precision 2D array elements (no result_image)", max_double_precision_2D_array) &
+          !,it("character scalar (no result_image)", max_double_precision_2D_array) &
+          !,it("character 2D array elements (no result_image)", max_double_precision_2D_array) &
+        ])
+    end function
+
+    function max_default_integer_scalars() result(result_)
+        type(result_t) result_
+        integer i
+ 
+        i = -caf_this_image()
+        call caf_co_max(i)
+        result_ = assert_equals(-1, i)
+    end function
+
+    function max_c_int64_scalars() result(result_)
+        use iso_c_binding, only : c_int64_t 
+        type(result_t) result_
+        integer(c_int64_t) i
+ 
+        i = caf_this_image()
+        call caf_co_max(i)
+        result_ = assert_equals(caf_num_images(), int(i))
+    end function
+
+    function max_default_integer_1D_array() result(result_)
+        type(result_t) result_
+        integer i
+        integer, allocatable :: array(:)
+ 
+        associate(sequence_ => caf_this_image()*[(i, i=1, caf_num_images())])
+          array = sequence_
+          call caf_co_max(array)
+          associate(max_sequence => caf_num_images()*[(i, i=1, caf_num_images())])
+            result_ = assert_that(all(max_sequence == array))
+          end associate
+        end associate
+    end function
+
+    function max_default_integer_7D_array() result(result_)
+        type(result_t) result_
+        integer array(2,1,1, 1,1,1, 2)
+ 
+        array = 3 + caf_this_image()
+        call caf_co_max(array)
+        result_ = assert_that(all(array == 3+caf_num_images()))
+    end function
+
+    function max_default_real_scalars() result(result_)
+        type(result_t) result_
+        real scalar
+        real, parameter :: pi = 3.141592654
+
+        scalar = -pi*caf_this_image()
+        call caf_co_max(scalar)
+        result_ = assert_equals(-dble(pi), dble(scalar) )
+    end function
+
+    function max_double_precision_2D_array() result(result_)
+        type(result_t) result_
+        double precision, allocatable :: array(:,:)
+        double precision, parameter :: tent(*,*) = dble(reshape(-[0,1,2,3,2,1], [3,2]))
+ 
+        array = tent*dble(caf_this_image())
+        call caf_co_max(array)
+        result_ = assert_that(all(array==tent))
+    end function
+
+   ! function max_default_character_scalars() result(result_)
+   !     type(result_t) result_
+   !     real scalar
+   !     character z
+   !     character, parameter :: i=(0.,1)
+
+   !     z = i
+   !     call caf_co_max(z)
+   !     result_ = assert_equals(dble(abs(i*caf_num_images())), dble(abs(z)) )
+   ! end function
+   !          
+   ! function max_double_precision_character_3D_arrays() result(result_)
+   !     type(result_t) result_
+   !     integer, parameter :: dp = kind(1.D0)
+   !     character(dp), allocatable :: array(:,:,:)
+   !     character(dp), parameter :: &
+   !       input(*,*,*) = reshape( [(-1.,0.) , (0.0,1.0), (1.0,0.0), (0.0,-1.0), (0.0,0.0), (0.0,1.0)], [3,1,2])
+ 
+   !     array = input
+   !     call caf_co_max(array)
+   !     result_ = assert_equals(dble(product(abs(input))*caf_num_images()), dble(product(abs(array))))
+   ! end function
+
+end module caf_co_max_test

--- a/test/main.f90
+++ b/test/main.f90
@@ -7,6 +7,8 @@ contains
     subroutine run()
         use a00_caffeinate_test, only: &
                 a00_caffeinate_caffeinate => test_caffeinate
+        use caf_co_max_test, only: &
+                caf_co_max_caf_co_max => test_caf_co_max
         use caf_co_min_test, only: &
                 caf_co_min_caf_co_min => test_caf_co_min
         use caf_co_sum_test, only: &
@@ -22,15 +24,16 @@ contains
         use vegetables, only: test_item_t, test_that, run_tests
 
         type(test_item_t) :: tests
-        type(test_item_t) :: individual_tests(7)
+        type(test_item_t) :: individual_tests(8)
 
         individual_tests(1) = a00_caffeinate_caffeinate()
-        individual_tests(2) = caf_co_min_caf_co_min()
-        individual_tests(3) = caf_co_sum_caf_co_sum()
-        individual_tests(4) = caf_error_stop_caf_this_image()
-        individual_tests(5) = caf_num_images_caf_num_images()
-        individual_tests(6) = caf_this_image_caf_this_image()
-        individual_tests(7) = zzz_decaffeinate_decaffeinate()
+        individual_tests(2) = caf_co_max_caf_co_max()
+        individual_tests(3) = caf_co_min_caf_co_min()
+        individual_tests(4) = caf_co_sum_caf_co_sum()
+        individual_tests(5) = caf_error_stop_caf_this_image()
+        individual_tests(6) = caf_num_images_caf_num_images()
+        individual_tests(7) = caf_this_image_caf_this_image()
+        individual_tests(8) = zzz_decaffeinate_decaffeinate()
         tests = test_that(individual_tests)
 
         call run_tests(tests)


### PR DESCRIPTION
To Do (in a future PR)
--------------------
1. Add optional arguments: `result_image`, `stat`, `errmsg`
2. Add add for collective reductions of `character(c_char)` data.