### PR TITLE
Fix installer Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -198,6 +198,9 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
     ask_permission_to_install_homebrew_package "gfortran, gcc, and g++" "gcc@$GCC_VERSION" 
     exit_if_user_declines "GCC"
     "$BREW" install gcc@$GCC_VERSION
+    if [ uname == "Linux" ]; then
+      brew link --force glibc
+    fi
   fi
   CC=`which gcc-$GCC_VERSION`
   CXX=`which g++-$GCC_VERSION`


### PR DESCRIPTION
On Linux, a recent Homebrew [change] requires executing `brew force-link glibc` after `brew link gcc`.  This PR adds this command where necessary in `install.sh`.

[change]: https://github.com/actions/runner-images/issues/6280#issuecomment-1257147693