### PR TITLE
Fix missing bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Paper: <https://doi.org/10.25344/S4459B>
 
 Documentation
 -------------
-One of our continous integration (CI) scripts generates up-to-date Caffeine documentation using [ford].  The CI script also deploys the generated documentation to the our GitHub Pages [site].
+One of our continuous integration (CI) scripts generates up-to-date Caffeine documentation using [ford].  The CI script also deploys the generated documentation to the our GitHub Pages [site].
 Alternatively, generate HTML documentation locally using [ford] as follows:
 ```
 ford doc-generator.md

--- a/doc-generator.md
+++ b/doc-generator.md
@@ -46,7 +46,7 @@ Philosophy and Motivations
 --------------------------
 * Write as much of Caffeine as possible in Fortran:
     - Writing the runtime library in the language of the users increases the likelihood of community contributions.
-    - Writing the runtime library in Fortran obviates the need to directly manipulate compiler descriptors throughout much of Caffeine and allows Caffeine's underlying C layer to receive the Fortran-standard `CFI_cdesc_t` desriptor, which imwill make it easier to support multiple compilers.
+    - Writing the runtime library in Fortran obviates the need to directly manipulate compiler descriptors throughout much of Caffeine and allows Caffeine's underlying C layer to receive the Fortran-standard `CFI_cdesc_t` descriptor, which will make it easier to support multiple compilers.
     - Writing most of Caffeine in Fortran offers the potential exploiting Fortran's rich array syntax, concurrent loop iterations (`do concurrent`), `pure` procedures and related features. Currently, these play a role only in one place: C callbacks to user-provided, `pure` functions that can be invoked inside a `do concurrent` block during the execution of `co_reduce`.
 * Define an interface that remains agnostic about the back-end communication library:
     - Once multiple back ends are supported, Fortran developers would not have to rewrite or even recompile their programs in order to change back ends. Switching from GASNet-EX to MPI, for example, could become a link-time decision.

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -239,9 +239,9 @@ bool caf_c_is_f_string(CFI_cdesc_t* a_desc){
   if ( (a_desc->type - 5) % 256 == 0) return true;
   return false;
 }
-#else // The code beow is untested but believed to conform with the Fortran 2018 standard.
+#else // The code below is untested but believed to conform with the Fortran 2018 standard.
 bool caf_c_is_f_string(CFI_cdesc_t* a_desc){
-  if ( (a_desc->type == CFI_type_char) return true;
+  if (a_desc->type == CFI_type_char) return true;
   return false;
 }
 #endif


### PR DESCRIPTION
This PR removes a leftover bracket in:
https://github.com/BerkeleyLab/caffeine/blob/38f2fd2c8d8017af37f74daeb85d1a5da04a23b9/src/caffeine/caffeine.c#L244

I also corrected a few minor typos as I was going through the README and documentation.
