### PR TITLE
Add beginnings of `rma` module

### DIFF
--- a/src/caffeine/rma_m.f90
+++ b/src/caffeine/rma_m.f90
@@ -1,0 +1,39 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+module rma_m
+  use team_type_m, only: team_type
+  implicit none
+
+  private
+  public :: caf_put, caf_get
+
+  type caf_co_handle
+  end type
+
+  interface
+
+   module subroutine caf_put(coarray, coindices, target, value, team, team_number, stat)
+      implicit none
+      type(caf_co_handle), intent(in) :: coarray
+      integer, intent(in) :: coindices(:)
+      type(*), dimension(..), intent(in) :: target, value
+      type(team_type), optional, intent(in) :: team
+      integer, optional, intent(in) :: team_number
+      integer, optional, intent(out) :: stat
+    end subroutine
+
+    module subroutine caf_get(coarray, coindices, source, value, team, team_number, stat)
+      implicit none
+      type(caf_co_handle), intent(in) :: coarray
+      integer, intent(in) :: coindices(:)
+      type(*), dimension(..), intent(in) :: source
+!     type(*), dimension(..), intent(out) :: value ! causes gfortran error: Assumed-type variable value at (1) may not have the INTENT(OUT) attribute
+      type(*), dimension(..), intent(inout) :: value
+      type(team_type), optional, intent(in) :: team
+      integer, optional, intent(in) :: team_number
+      integer, optional, intent(out) :: stat
+    end subroutine
+
+  end interface
+
+end module rma_m

--- a/src/caffeine/rma_s.f90
+++ b/src/caffeine/rma_s.f90
@@ -1,13 +1,15 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(rma_m) rma_s
+  use caffeine_assert_m, only : assert
 
   implicit none
 
 contains
 
   module procedure caf_put
-    ! assert that both team and team_number are not present
+
+    call assert(.not.(present(team) .and. present(team_number)), "caf_put: both team and team_number are present")
 
     ! assert that the size of coindices array needs to match the corank of the coarray
 

--- a/src/caffeine/rma_s.f90
+++ b/src/caffeine/rma_s.f90
@@ -1,0 +1,31 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+submodule(rma_m) rma_s
+
+  implicit none
+
+contains
+
+  module procedure caf_put
+    ! assert that both team and team_number are not present
+
+    ! assert that the size of coindices array needs to match the corank of the coarray
+
+    ! assert that target and value need to be of the same type
+    ! assert that target and value need to have the same shape (rank, size of each dimension)
+    ! strides may be different for target and value
+
+    ! values of the coindices must be within the bounds of the codimensions
+
+    ! to do bounds checking, need to do translation between team and the team where the coarray was established
+    ! need to set up coindices with respect to the provided team
+
+    ! need to figure out which image we are dealing with
+    ! caffeine should already have the coshape information
+  end procedure
+
+  module procedure caf_get
+
+  end procedure
+
+end submodule rma_s


### PR DESCRIPTION
Add the beginnings of a module to add gets and puts. This was drafted collectively in a meeting and have now been translated into compilable code. The name and placement of the module are just suggestions and very much open to feedback.