### PR TITLE
Add to `prif_image_index` ability to handle cases of invalid cosubscripts

### DIFF
--- a/src/caffeine/coarray_queries_s.f90
+++ b/src/caffeine/coarray_queries_s.f90
@@ -1,6 +1,7 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(coarray_queries_m) coarray_queries_s
+  use image_queries_m, only: prif_num_images
 
   implicit none
 
@@ -22,15 +23,32 @@ contains
   end procedure
 
   module procedure prif_image_index
-    integer :: dim
-    integer(c_int) :: prior_size
+    integer :: dim, i
+    integer(c_int) :: prior_size, num_img
+    logical :: invalid_cosubscripts
 
-    image_index = 1 + sub(1) - coarray_handle%info%lcobounds(1)
-    prior_size = 1
-    do dim = 2, size(sub)
-      prior_size = prior_size * (coarray_handle%info%ucobounds(dim-1) - coarray_handle%info%lcobounds(dim-1) + 1)
-      image_index = image_index + (sub(dim) - coarray_handle%info%lcobounds(dim)) * prior_size
-    end do
+    invalid_cosubscripts = .false.
+
+    check_subscripts: do i = 1, size(sub)
+       if (sub(i) .lt. coarray_handle%info%lcobounds(i) .or. sub(i) .gt. coarray_handle%info%ucobounds(i)) then
+          invalid_cosubscripts = .true.
+          exit check_subscripts
+       end if
+    end do check_subscripts
+
+    if (.not. invalid_cosubscripts) then
+      image_index = 1 + sub(1) - coarray_handle%info%lcobounds(1)
+      prior_size = 1
+      do dim = 2, size(sub)
+        prior_size = prior_size * (coarray_handle%info%ucobounds(dim-1) - coarray_handle%info%lcobounds(dim-1) + 1)
+        image_index = image_index + (sub(dim) - coarray_handle%info%lcobounds(dim)) * prior_size
+       end do
+    end if
+
+    call prif_num_images(image_count=num_img)
+    if (invalid_cosubscripts .or. image_index .gt. num_img) then
+       image_index = 0
+    end if
   end procedure
 
 end submodule coarray_queries_s

--- a/test/caf_image_index_test.f90
+++ b/test/caf_image_index_test.f90
@@ -14,6 +14,7 @@ contains
           "prif_image_index", &
           [ it("returns 1 for the simplest case", check_simple_case) &
           , it("returns 1 when given the lower bounds", check_lower_bounds) &
+          , it("returns 0 with invalid subscripts", check_invalid_subscripts) &
           , it("returns the expected answer for a more complicated case", check_complicated) &
           ])
     end function
@@ -57,6 +58,27 @@ contains
                 allocated_memory = allocated_memory)
         call prif_image_index(coarray_handle, [2_c_intmax_t, 3_c_intmax_t], image_index=answer)
         result_ = assert_equals(1_c_int, answer)
+        call prif_deallocate([coarray_handle])
+    end function
+
+    function check_invalid_subscripts() result(result_)
+        type(result_t) :: result_
+
+        type(prif_coarray_handle) :: coarray_handle
+        type(c_ptr) :: allocated_memory
+        integer(c_int) :: answer
+
+        call prif_allocate( &
+                lcobounds = [-2_c_intmax_t, 2_c_intmax_t], &
+                ucobounds = [2_c_intmax_t, 6_c_intmax_t], &
+                lbounds = [integer(c_intmax_t)::], &
+                ubounds = [integer(c_intmax_t)::], &
+                element_length = 1_c_size_t, &
+                final_func = c_null_funptr, &
+                coarray_handle = coarray_handle, &
+                allocated_memory = allocated_memory)
+        call prif_image_index(coarray_handle, [-1_c_intmax_t, 1_c_intmax_t], image_index=answer)
+        result_ = assert_equals(0_c_int, answer)
         call prif_deallocate([coarray_handle])
     end function
 


### PR DESCRIPTION
Add to `prif_image_index` ability to handle cases of invalid cosubscripts by returning zero. Add case in image_index test