### PR TITLE
add tests exposing co_broadcast and co_reduce bugs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -344,13 +344,15 @@ echo "Version: 0.1.0"                                             >> $CAFFEINE_P
 exit_if_pkg_config_pc_file_missing "caffeine"
 
 RUN_FPM_SH="build/run-fpm.sh"
-echo "#!/bin/sh"                                                              >  $RUN_FPM_SH
-echo "#-- DO NOT EDIT -- created by caffeine/install.sh"                      >> $RUN_FPM_SH
-echo "\"${FPM}\" \"\$@\" \\"                                                  >> $RUN_FPM_SH
-echo "--compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`\"   \\"  >> $RUN_FPM_SH
-echo "--c-compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`\" \\"  >> $RUN_FPM_SH
-echo "--c-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`\" \\"  >> $RUN_FPM_SH
-echo "--link-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`\"" >> $RUN_FPM_SH
+echo "#!/bin/sh"                                                                 >  $RUN_FPM_SH
+echo "#-- DO NOT EDIT -- created by caffeine/install.sh"                         >> $RUN_FPM_SH
+echo "fpm_sub_cmd=\$1; shift"                                                    >> $RUN_FPM_SH
+echo "\"${FPM}\" \"\$fpm_sub_cmd\" \\"                                           >> $RUN_FPM_SH
+echo "--compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`\"   \\"     >> $RUN_FPM_SH
+echo "--c-compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`\" \\"     >> $RUN_FPM_SH
+echo "--c-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`\" \\"     >> $RUN_FPM_SH
+echo "--link-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`\" \\" >> $RUN_FPM_SH
+echo "\"\$@\""                                                                   >> $RUN_FPM_SH
 chmod u+x $RUN_FPM_SH
 
 ./$RUN_FPM_SH build

--- a/manifest/fpm.toml.template
+++ b/manifest/fpm.toml.template
@@ -6,7 +6,7 @@ maintainer = "rouson@lbl.gov"
 copyright = "2021-2022 UC Regents"
 
 [dev-dependencies]
-veggies = {git = "https://gitlab.com/everythingfunctional/veggies", tag = "v1.0.5"}
+veggies = {git = "https://gitlab.com/everythingfunctional/veggies", tag = "v1.1.0"}
 iso_varying_string = {git = "https://gitlab.com/everythingfunctional/iso_varying_string.git", tag = "v3.0.4"}
 
 [build]


### PR DESCRIPTION
To demonstrate the presence of the bugs you can run the isolated tests with either:

```text
GASNET_PSHM_NODES=2 ./build/run-fpm.sh test -- -f '(caffeinate|co_broadcast)' -f '(caffeinate|derived type)' -d
```
or
```text
GASNET_PSHM_NODES=2 ./build/run-fpm.sh test -- -f '(caffeinate|co_reduce)' -f '(caffeinate|derived type)' -d
```