### PR TITLE
Remove `stat` and `errmsg` args from `caf` collectives interfaces

### DIFF
--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -179,9 +179,11 @@ static void set_stat_errmsg_or_abort(int* stat, char* errmsg, const int return_s
   }
 }
 
-void caf_co_max(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements, gex_TM_t team)
+void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
+  int* stat;
+  char* errmsg;
 
   switch (a_desc->type)
   {

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -239,9 +239,11 @@ void caf_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
   gex_Event_Wait(ev);
 }
 
-void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements, gex_TM_t team)
+void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
+  int* stat = NULL;
+  char* errmsg = NULL;
 
   size_t c_sizeof_a = a_desc->elem_len;
 
@@ -267,8 +269,6 @@ void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, 
     ev = gex_Coll_ReduceToAllNB(team,                 a_address, a_address, a_type, c_sizeof_a, num_elements, GEX_OP_ADD, NULL, NULL, 0);
   }
   gex_Event_Wait(ev);
-
-  if (stat != NULL) *stat = 0;
 }
 
 bool caf_same_cfi_type(CFI_cdesc_t* a_desc, CFI_cdesc_t* b_desc)

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -250,7 +250,7 @@ void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     case float_Complex_workaround:  a_type = GEX_DT_FLT; num_elements *= 2; c_sizeof_a /= 2; break;
     case double_Complex_workaround: a_type = GEX_DT_DBL; num_elements *= 2; c_sizeof_a /= 2; break;
     default:
-      set_stat_errmsg_or_abort(NULL, NULL, UNRECOGNIZED_TYPE, "");
+      gasnett_fatalerror("Unrecognized type: %d", (int)a_desc->type);
   }
 
   char* a_address = (char*) a_desc->base_addr;

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -182,8 +182,8 @@ static void set_stat_errmsg_or_abort(int* stat, char* errmsg, const int return_s
 void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
-  int* stat;
-  char* errmsg;
+  int* stat = NULL;
+  char* errmsg = NULL;
 
   switch (a_desc->type)
   {
@@ -207,8 +207,6 @@ void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     ev = gex_Coll_ReduceToAllNB(team,                 a_address, a_address, a_type, c_sizeof_a, num_elements, GEX_OP_MAX, NULL, NULL, 0);
   }
   gex_Event_Wait(ev);
-
-  if (stat != NULL) *stat = 0;
 }
 
 void caf_co_min(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements, gex_TM_t team)

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -190,7 +190,7 @@ void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     case CFI_type_float:            a_type = GEX_DT_FLT; break;
     case CFI_type_double:           a_type = GEX_DT_DBL; break;
     default:
-      set_stat_errmsg_or_abort(NULL, NULL, UNRECOGNIZED_TYPE, "");
+      gasnett_fatalerror("Unrecognized type: %d", (int)a_desc->type);
   }
 
   char* a_address = (char*) a_desc->base_addr;

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -209,9 +209,11 @@ void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
   gex_Event_Wait(ev);
 }
 
-void caf_co_min(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements, gex_TM_t team)
+void caf_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
+  int* stat = NULL;
+  char* errmsg = NULL;
 
   switch (a_desc->type)
   {
@@ -235,8 +237,6 @@ void caf_co_min(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, 
     ev = gex_Coll_ReduceToAllNB(team,                 a_address, a_address, a_type, c_sizeof_a, num_elements, GEX_OP_MIN, NULL, NULL, 0);
   }
   gex_Event_Wait(ev);
-
-  if (stat != NULL) *stat = 0;
 }
 
 void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements, gex_TM_t team)

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -182,8 +182,6 @@ static void set_stat_errmsg_or_abort(int* stat, char* errmsg, const int return_s
 void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
-  int* stat = NULL;
-  char* errmsg = NULL;
 
   switch (a_desc->type)
   {
@@ -192,7 +190,7 @@ void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     case CFI_type_float:            a_type = GEX_DT_FLT; break;
     case CFI_type_double:           a_type = GEX_DT_DBL; break;
     default:
-      set_stat_errmsg_or_abort(stat, errmsg, UNRECOGNIZED_TYPE, "");
+      set_stat_errmsg_or_abort(NULL, NULL, UNRECOGNIZED_TYPE, "");
   }
 
   char* a_address = (char*) a_desc->base_addr;
@@ -212,8 +210,6 @@ void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
 void caf_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
-  int* stat = NULL;
-  char* errmsg = NULL;
 
   switch (a_desc->type)
   {
@@ -222,7 +218,7 @@ void caf_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     case CFI_type_float:            a_type = GEX_DT_FLT; break;
     case CFI_type_double:           a_type = GEX_DT_DBL; break;
     default:
-      set_stat_errmsg_or_abort(stat, errmsg, UNRECOGNIZED_TYPE, "");
+      set_stat_errmsg_or_abort(NULL, NULL, UNRECOGNIZED_TYPE, "");
   }
 
   char* a_address = (char*) a_desc->base_addr;
@@ -242,8 +238,6 @@ void caf_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
 void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;
-  int* stat = NULL;
-  char* errmsg = NULL;
 
   size_t c_sizeof_a = a_desc->elem_len;
 
@@ -256,7 +250,7 @@ void caf_co_sum(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     case float_Complex_workaround:  a_type = GEX_DT_FLT; num_elements *= 2; c_sizeof_a /= 2; break;
     case double_Complex_workaround: a_type = GEX_DT_DBL; num_elements *= 2; c_sizeof_a /= 2; break;
     default:
-      set_stat_errmsg_or_abort(stat, errmsg, UNRECOGNIZED_TYPE, "");
+      set_stat_errmsg_or_abort(NULL, NULL, UNRECOGNIZED_TYPE, "");
   }
 
   char* a_address = (char*) a_desc->base_addr;

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -149,7 +149,7 @@ void caf_co_reduce(
   gex_Event_Wait(ev);
 }
 
-void caf_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int* stat, int num_elements, gex_TM_t team)
+void caf_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int num_elements, gex_TM_t team)
 {
   char* c_loc_a = (char*) a_desc->base_addr;
   size_t c_sizeof_a = a_desc->elem_len;
@@ -160,8 +160,6 @@ void caf_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int* stat, int num
   gex_Event_t ev
     = gex_Coll_BroadcastNB(team, source_image-1, c_loc_a, c_loc_a, nbytes, 0);
   gex_Event_Wait(ev);
-
-  if (stat != NULL) *stat = 0;
 }
 
 static void set_stat_errmsg_or_abort(int* stat, char* errmsg, const int return_stat, const char* return_message)

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -130,7 +130,7 @@ void caf_sync_all()
 }
 
 void caf_co_reduce(
-  CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, int num_elements, gex_Coll_ReduceFn_t* user_op, void* client_data, gex_TM_t team
+  CFI_cdesc_t* a_desc, int result_image, int num_elements, gex_Coll_ReduceFn_t* user_op, void* client_data, gex_TM_t team
 )
 {
   char* a_address = (char*) a_desc->base_addr;
@@ -147,8 +147,6 @@ void caf_co_reduce(
     );
   }
   gex_Event_Wait(ev);
-
-  if (stat != NULL) *stat = 0;
 }
 
 void caf_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int* stat, int num_elements, gex_TM_t team)

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -218,7 +218,7 @@ void caf_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_
     case CFI_type_float:            a_type = GEX_DT_FLT; break;
     case CFI_type_double:           a_type = GEX_DT_DBL; break;
     default:
-      set_stat_errmsg_or_abort(NULL, NULL, UNRECOGNIZED_TYPE, "");
+      gasnett_fatalerror("Unrecognized type: %d", (int)a_desc->type);
   }
 
   char* a_address = (char*) a_desc->base_addr;

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -162,23 +162,6 @@ void caf_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int num_elements, 
   gex_Event_Wait(ev);
 }
 
-static void set_stat_errmsg_or_abort(int* stat, char* errmsg, const int return_stat, const char* return_message)
-{
-  if (stat == NULL && errmsg == NULL) gasnett_fatalerror("%s", return_message);
-
-  if (stat != NULL) *stat = return_stat;
-
-  if (errmsg != NULL) {
-    if (strlen(errmsg) >= strlen(return_message)) {
-      // TODO: Figure out how/whether to handle repositioning of the null terminator.
-      errmsg = return_message;
-    } else {
-      // TODO: Figure out how to replace this with an assignment of a truncated error message.
-      gasnett_fatalerror("%s", "caffeine.c: strlen(errmsg) too small");
-    }
-  }
-}
-
 void caf_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team)
 {
   gex_DT_t a_type;

--- a/src/caffeine/caffeine_h_m.f90
+++ b/src/caffeine/caffeine_h_m.f90
@@ -143,13 +143,12 @@ module caffeine_h_m
        type(c_ptr), value :: team
      end subroutine
 
-     subroutine caf_co_min(a, result_image, c_loc_stat, c_loc_errmsg, num_elements, team) bind(C)
-       !! void c_co_min(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements);
+     subroutine caf_co_min(a, result_image, num_elements, team) bind(C)
+       !! void c_co_min(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team);
        import c_int, c_ptr, c_size_t
        implicit none 
        type(*) a(..)
        integer(c_int), value :: result_image
-       type(c_ptr), value :: c_loc_stat, c_loc_errmsg
        integer(c_size_t), value :: num_elements
        type(c_ptr), value :: team
      end subroutine

--- a/src/caffeine/caffeine_h_m.f90
+++ b/src/caffeine/caffeine_h_m.f90
@@ -154,13 +154,12 @@ module caffeine_h_m
        type(c_ptr), value :: team
      end subroutine
 
-     subroutine caf_co_max(a, result_image, c_loc_stat, c_loc_errmsg, num_elements, team) bind(C)
-       !! void c_co_max(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements);
+     subroutine caf_co_max(a, result_image, num_elements, team) bind(C)
+       !! void c_co_max(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team);
        import c_int, c_ptr, c_size_t
        implicit none 
        type(*) a(..)
        integer(c_int), value :: result_image
-       type(c_ptr), value :: c_loc_stat, c_loc_errmsg
        integer(c_size_t), value :: num_elements
        type(c_ptr), value :: team
      end subroutine

--- a/src/caffeine/caffeine_h_m.f90
+++ b/src/caffeine/caffeine_h_m.f90
@@ -111,12 +111,11 @@ module caffeine_h_m
 
     ! ______________ Collective Subroutines __________________
 
-     subroutine caf_co_broadcast(a, source_image, stat, Nelem, team) bind(C)
-       !! void c_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int* stat, int num_elements);
+     subroutine caf_co_broadcast(a, source_image, Nelem, team) bind(C)
+       !! void c_co_broadcast(CFI_cdesc_t * a_desc, int source_image, int num_elements, gex_TM_t team);
        import c_int, c_ptr
        implicit none
        type(*) a(..)
-       type(c_ptr), value :: stat
        integer(c_int), value :: source_image, Nelem
        type(c_ptr), value :: team
      end subroutine

--- a/src/caffeine/caffeine_h_m.f90
+++ b/src/caffeine/caffeine_h_m.f90
@@ -121,13 +121,13 @@ module caffeine_h_m
        type(c_ptr), value :: team
      end subroutine
 
-     subroutine caf_co_reduce(a, result_image, c_loc_stat, c_loc_errmsg, num_elements, Coll_ReduceSub, client_data, team) bind(C)
-       !! void caf_co_reduce(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, int num_elements, gex_Coll_ReduceFn_t* user_op, void* client_data)
+     subroutine caf_co_reduce(a, result_image, num_elements, Coll_ReduceSub, client_data, team) bind(C)
+       !! void caf_co_reduce(CFI_cdesc_t* a_desc, int result_image, int num_elements, gex_Coll_ReduceFn_t* user_op, void* client_data)
        import c_int, c_ptr, c_size_t, c_funptr
        implicit none 
        type(*) a(..)
        integer(c_int), value :: result_image
-       type(c_ptr), value :: c_loc_stat, c_loc_errmsg, client_data
+       type(c_ptr), value :: client_data
        type(c_funptr), value :: Coll_ReduceSub
        integer(c_size_t), value :: num_elements
        type(c_ptr), value :: team

--- a/src/caffeine/caffeine_h_m.f90
+++ b/src/caffeine/caffeine_h_m.f90
@@ -132,13 +132,12 @@ module caffeine_h_m
        type(c_ptr), value :: team
      end subroutine
 
-     subroutine caf_co_sum(a, result_image, c_loc_stat, c_loc_errmsg, num_elements, team) bind(C)
-       !! void c_co_sum(CFI_cdesc_t* a_desc, int result_image, int* stat, char* errmsg, size_t num_elements);
+     subroutine caf_co_sum(a, result_image, num_elements, team) bind(C)
+       !! void c_co_sum(CFI_cdesc_t* a_desc, int result_image, size_t num_elements, gex_TM_t team);
        import c_int, c_ptr, c_size_t
        implicit none 
        type(*) a(..)
        integer(c_int), value :: result_image
-       type(c_ptr), value :: c_loc_stat, c_loc_errmsg
        integer(c_size_t), value :: num_elements
        type(c_ptr), value :: team
      end subroutine

--- a/src/caffeine/collective_subroutines/co_broadcast_s.f90
+++ b/src/caffeine/collective_subroutines/co_broadcast_s.f90
@@ -12,7 +12,7 @@ contains
     stat_ptr = get_c_ptr(stat)
 
     call caf_co_broadcast(a, source_image, stat_ptr, product(shape(a)), current_team%gex_team)
-      ! With a compliant Fortran 2018 compiler, pass in c_sizeof(a) as the final argument
+      ! With a compliant Fortran 2018 compiler, pass in c_sizeof(a) as the `Nelem` argument
       ! and eliminate the calculation of num_elements*sizeof(a) in caffeine.c.
   end procedure
 

--- a/src/caffeine/collective_subroutines/co_broadcast_s.f90
+++ b/src/caffeine/collective_subroutines/co_broadcast_s.f90
@@ -1,5 +1,4 @@
 submodule(prif:prif_private_s)  co_broadcast_s
-  use utilities_m, only : get_c_ptr
   use caffeine_h_m, only : caf_co_broadcast
 
   implicit none
@@ -7,11 +6,8 @@ submodule(prif:prif_private_s)  co_broadcast_s
 contains
 
   module procedure prif_co_broadcast
-    type(c_ptr) stat_ptr
-
-    stat_ptr = get_c_ptr(stat)
-
-    call caf_co_broadcast(a, source_image, stat_ptr, product(shape(a)), current_team%gex_team)
+    if (present(stat)) stat=0
+    call caf_co_broadcast(a, source_image, product(shape(a)), current_team%gex_team)
       ! With a compliant Fortran 2018 compiler, pass in c_sizeof(a) as the `Nelem` argument
       ! and eliminate the calculation of num_elements*sizeof(a) in caffeine.c.
   end procedure

--- a/src/caffeine/collective_subroutines/co_max_s.f90
+++ b/src/caffeine/collective_subroutines/co_max_s.f90
@@ -16,7 +16,7 @@ contains
       call caf_co_max( &
           a, optional_value(result_image), int(product(shape(a)), c_size_t), current_team%gex_team)
     else if (caf_is_f_string(a)) then
-      call prif_co_reduce(a, c_funloc(reverse_alphabetize), optional_value(result_image), stat, errmsg)
+      call prif_co_reduce(a, c_funloc(reverse_alphabetize), optional_value(result_image), stat, errmsg, errmsg_alloc)
     else
       call prif_error_stop(.false._c_bool, stop_code_char="caf_co_max: unsupported type")
     end if

--- a/src/caffeine/collective_subroutines/co_max_s.f90
+++ b/src/caffeine/collective_subroutines/co_max_s.f90
@@ -1,31 +1,20 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) co_max_s
-  use iso_c_binding, only : c_null_char, c_f_pointer, c_funloc, c_null_ptr
-  use utilities_m, only : get_c_ptr, get_c_ptr_character, optional_value
-  use caffeine_h_m, only : caf_co_max, caf_same_cfi_type, caf_numeric_type, caf_is_f_string
+  use iso_c_binding, only : c_funloc
+  use utilities_m, only : optional_value
+  use caffeine_h_m, only : caf_co_max, caf_numeric_type, caf_is_f_string
 
   implicit none
 
 contains
 
   module procedure prif_co_max
-    type(c_ptr) :: stat_c_ptr = c_null_ptr, errmsg_c_ptr = c_null_ptr
-    character(len=:), allocatable :: c_string
-    character(len=:), pointer :: errmsg_f_ptr
+    if (present(stat)) stat=0
 
     if (caf_numeric_type(a)) then
-
-      stat_c_ptr = get_c_ptr(stat)
-      c_string = errmsg // c_null_char
-      errmsg_c_ptr = get_c_ptr_character(c_string)
-
       call caf_co_max( &
-          a, optional_value(result_image), stat_c_ptr, errmsg_c_ptr, int(product(shape(a)), c_size_t), current_team%gex_team)
-
-      call c_f_pointer(errmsg_c_ptr, errmsg_f_ptr) ! no need to do this for stat was passed by reference
-      errmsg = errmsg_f_ptr ! copy the output back & truncate the null terminator
-
+          a, optional_value(result_image), int(product(shape(a)), c_size_t), current_team%gex_team)
     else if (caf_is_f_string(a)) then
       call prif_co_reduce(a, c_funloc(reverse_alphabetize), optional_value(result_image), stat, errmsg)
     else

--- a/src/caffeine/collective_subroutines/co_min_s.f90
+++ b/src/caffeine/collective_subroutines/co_min_s.f90
@@ -1,31 +1,20 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) co_min_s
-  use iso_c_binding, only : c_null_char, c_f_pointer, c_funloc, c_null_ptr
-  use utilities_m, only : get_c_ptr, get_c_ptr_character, optional_value
-  use caffeine_h_m, only : caf_co_min, caf_same_cfi_type, caf_numeric_type, caf_is_f_string
+  use iso_c_binding, only : c_funloc
+  use utilities_m, only : optional_value
+  use caffeine_h_m, only : caf_co_min, caf_numeric_type, caf_is_f_string
 
   implicit none
 
 contains
 
   module procedure prif_co_min
-    type(c_ptr) :: stat_c_ptr = c_null_ptr, errmsg_c_ptr = c_null_ptr
-    character(len=:), allocatable :: c_string
-    character(len=:), pointer :: errmsg_f_ptr
+    if (present(stat)) stat=0
 
     if (caf_numeric_type(a)) then
-
-      stat_c_ptr = get_c_ptr(stat)
-      c_string = errmsg // c_null_char
-      errmsg_c_ptr = get_c_ptr_character(c_string)
-
       call caf_co_min( &
-          a, optional_value(result_image), stat_c_ptr, errmsg_c_ptr, int(product(shape(a)), c_size_t), current_team%gex_team)
-
-      call c_f_pointer(errmsg_c_ptr, errmsg_f_ptr) ! no need to do this for stat was passed by reference
-      errmsg = errmsg_f_ptr ! copy the output back & truncate the null terminator
-
+          a, optional_value(result_image), int(product(shape(a)), c_size_t), current_team%gex_team)
     else if (caf_is_f_string(a)) then
       call prif_co_reduce(a, c_funloc(alphabetize), optional_value(result_image), stat, errmsg)
     else

--- a/src/caffeine/collective_subroutines/co_min_s.f90
+++ b/src/caffeine/collective_subroutines/co_min_s.f90
@@ -16,7 +16,7 @@ contains
       call caf_co_min( &
           a, optional_value(result_image), int(product(shape(a)), c_size_t), current_team%gex_team)
     else if (caf_is_f_string(a)) then
-      call prif_co_reduce(a, c_funloc(alphabetize), optional_value(result_image), stat, errmsg)
+      call prif_co_reduce(a, c_funloc(alphabetize), optional_value(result_image), stat, errmsg, errmsg_alloc)
     else
       call prif_error_stop(.false._c_bool, stop_code_char="prif_co_min: unsupported type")
     end if

--- a/src/caffeine/collective_subroutines/co_sum_s.f90
+++ b/src/caffeine/collective_subroutines/co_sum_s.f90
@@ -1,8 +1,7 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) co_sum_s
-  use iso_c_binding, only : c_null_char, c_f_pointer, c_null_ptr
-  use utilities_m, only : get_c_ptr, get_c_ptr_character, optional_value
+  use utilities_m, only : optional_value
   use caffeine_h_m, only : caf_co_sum
 
   implicit none
@@ -10,14 +9,10 @@ submodule(prif:prif_private_s) co_sum_s
 contains
 
   module procedure prif_co_sum
-    type(c_ptr) stat_c_ptr, errmsg_c_ptr
-
-    stat_c_ptr = c_null_ptr
-    errmsg_c_ptr = c_null_ptr
     if (present(stat)) stat=0
 
     call caf_co_sum( &
-        a, optional_value(result_image), stat_c_ptr, errmsg_c_ptr, int(product(shape(a)), c_size_t), current_team%gex_team)
+        a, optional_value(result_image), int(product(shape(a)), c_size_t), current_team%gex_team)
   end procedure
 
 end submodule co_sum_s


### PR DESCRIPTION
Closes #81.