### PR TITLE
Create prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,15 +94,11 @@ if command -v fpm > /dev/null 2>&1; then
   FPM=`which fpm`
 fi
 
-if command -v gmkdir > /dev/null 2>&1; then
-  GMKDIR=`which gmkdir`
-fi 
-
 ask_permission_to_use_homebrew()
 {
   echo ""
   echo "Either one or more of the environment variables FC, CC, and CXX are unset or"
-  echo "one or more of the following packages are not in the PATH: pkg-config, realpath, make, gmkdir, fpm."
+  echo "one or more of the following packages are not in the PATH: pkg-config, realpath, make, fpm."
   echo "If you grant permission to install prerequisites, you will be prompted before each installation." 
   echo ""
   echo "Press 'Enter' to choose the square-bracketed default answer:"
@@ -159,7 +155,7 @@ if [ ! -d $DEPENDENCIES_DIR ]; then
   mkdir -p $DEPENDENCIES_DIR
 fi
 
-if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] || [ -z ${FPM+x} ] || [ -z ${GMKDIR+x} ] ; then
+if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ] || [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] || [ -z ${FPM+x} ] ; then
 
   ask_permission_to_use_homebrew 
   exit_if_user_declines "brew"
@@ -210,8 +206,8 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
   CXX=`which g++-$GCC_VERSION`
   FC=`which gfortran-$GCC_VERSION`
 
-  if [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ]  || [ -z ${GMKDIR+x} ] ; then
-    ask_permission_to_install_homebrew_package "'realpath', 'make', and 'gmkdir'" "coreutils"
+  if [ -z ${REALPATH+x} ] || [ -z ${MAKE+x} ] ; then
+    ask_permission_to_install_homebrew_package "'realpath' and 'make'" "coreutils"
     exit_if_user_declines "realpath"
     "$BREW" install coreutils
   fi

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ print_usage_info()
     echo "./install.sh [--help | [--prefix=PREFIX]"
     echo ""
     echo " --help             Display this help text"
-    echo " --prefix=PREFIX    Install binary in 'PREFIX/bin'"
+    echo " --prefix=PREFIX    Install library into 'PREFIX' directory"
     echo " --prereqs          Display a list of prerequisite software."
     echo "                    Default prefix='\$HOME/.local/bin'"
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -229,7 +229,9 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
   FPM=`which fpm`
 fi
 
-PREFIX=`$REALPATH ${PREFIX:-"${HOME}/.local"}`
+PREFIX=${PREFIX:-"${HOME}/.local"}
+mkdir -p $PREFIX
+PREFIX=`$REALPATH $PREFIX`
 echo "PREFIX=$PREFIX"
 
 if [ -z ${PKG_CONFIG_PATH+x} ]; then


### PR DESCRIPTION
Teach install.sh to create --prefix directory if it doesn't already exist.   
This matches the default behavior of autotools and CMake that users generally expect.

Also, stop requiring gmkdir. 
Regular mkdir is sufficient for our purposes, and the install script
was already relying on its availability anyhow prior to installing   gmkdir.