### PR TITLE
Revert "Change installer to use specific gasnet version for the release"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ print_usage_info()
 }
 
 GCC_VERSION=13
-GASNET_VERSION="2023.9.0"
+GASNET_VERSION="stable"
 
 list_prerequisites()
 {


### PR DESCRIPTION
Revert temporary change to gasnet version in install script that is only needed for the release.