### PR TITLE
Support LLVM Flang (flang-new)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Run unit tests
       run: |
         export GASNET_PSHM_NODES=8
-        ./build/run-fpm.sh test
+        ./build/run-fpm.sh test -- -d

--- a/install.sh
+++ b/install.sh
@@ -397,9 +397,9 @@ exit_if_pkg_config_pc_file_missing "caffeine"
 
 compiler_version=$($FPM_FC --version)
 if [[ $compiler_version == *llvm* ]]; then
-  compiler_flag="-mmlir -allow-assumed-rank -Ofast"
+  compiler_flag="-mmlir -allow-assumed-rank -g -Ofast"
 else
-  compiler_flag="-O3"
+  compiler_flag="-g -O3"
 fi
 
 RUN_FPM_SH="build/run-fpm.sh"
@@ -408,7 +408,7 @@ cat << EOF > $RUN_FPM_SH
 #-- DO NOT EDIT -- created by caffeine/install.sh
 fpm_sub_cmd=\$1; shift
 "${FPM}" "\$fpm_sub_cmd" \\
---profile release \\
+--profile debug \\
 --flag "$compiler_flag" \\
 --compiler "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`"   \\
 --c-compiler "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`" \\

--- a/install.sh
+++ b/install.sh
@@ -273,7 +273,9 @@ fi
 echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
 
 FPM_FC="$($REALPATH $(command -v $FC))"
-FPM_FC=${FPM_FC/flang-20/flang-new}
+if [[ $FPM_FC == *flang* ]]; then
+  FPM_FC=${FPM_FC/flang-20/flang-new}
+fi
 FPM_CC="$($REALPATH $(command -v $CC))"
 
 ask_package_permission()

--- a/install.sh
+++ b/install.sh
@@ -273,6 +273,7 @@ fi
 echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
 
 FPM_FC="$($REALPATH $(command -v $FC))"
+FPM_FC=${FPM_FC/flang-20/flang-new}
 FPM_CC="$($REALPATH $(command -v $CC))"
 
 ask_package_permission()

--- a/install.sh
+++ b/install.sh
@@ -395,12 +395,21 @@ EOF
 
 exit_if_pkg_config_pc_file_missing "caffeine"
 
+compiler_version=$($FPM_FC --version)
+if [[ $compiler_version == *llvm* ]]; then
+  compiler_flag="-mmlir -allow-assumed-rank -Ofast"
+else
+  compiler_flag="-O3"
+fi
+
 RUN_FPM_SH="build/run-fpm.sh"
 cat << EOF > $RUN_FPM_SH
 #!/bin/sh
 #-- DO NOT EDIT -- created by caffeine/install.sh
 fpm_sub_cmd=\$1; shift
 "${FPM}" "\$fpm_sub_cmd" \\
+--profile release \\
+--flag "$compiler_flag" \\
 --compiler "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`"   \\
 --c-compiler "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`" \\
 --c-flag "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`" \\

--- a/manifest/fpm.toml.template
+++ b/manifest/fpm.toml.template
@@ -6,7 +6,7 @@ maintainer = "rouson@lbl.gov"
 copyright = "2021-2024 UC Regents"
 
 [dev-dependencies]
-veggies = {git = "https://gitlab.com/everythingfunctional/veggies"}
+veggies = {git = "https://gitlab.com/everythingfunctional/veggies", tag = "v1.1.3"}
 iso_varying_string = {git = "https://gitlab.com/everythingfunctional/iso_varying_string.git", tag = "v3.0.4"}
 
 [build]

--- a/manifest/fpm.toml.template
+++ b/manifest/fpm.toml.template
@@ -6,7 +6,7 @@ maintainer = "rouson@lbl.gov"
 copyright = "2021-2024 UC Regents"
 
 [dev-dependencies]
-veggies = {git = "https://gitlab.com/everythingfunctional/veggies", tag = "v1.1.2"}
+veggies = {git = "https://gitlab.com/everythingfunctional/veggies"}
 iso_varying_string = {git = "https://gitlab.com/everythingfunctional/iso_varying_string.git", tag = "v3.0.4"}
 
 [build]

--- a/src/caffeine/collective_subroutines/co_max_s.f90
+++ b/src/caffeine/collective_subroutines/co_max_s.f90
@@ -23,7 +23,7 @@ contains
 
     function reverse_alphabetize(lhs, rhs) result(last_alphabetically)
       character(len=*), intent(in) :: lhs, rhs
-      character(len=:), allocatable :: last_alphabetically
+      character(len=len(lhs)) :: last_alphabetically
       call assert(len(lhs)==len(rhs), "caf_co_max: LHS/RHS length match", lhs//" , "//rhs)
       last_alphabetically = max(lhs,rhs)
     end function

--- a/src/caffeine/collective_subroutines/co_min_s.f90
+++ b/src/caffeine/collective_subroutines/co_min_s.f90
@@ -23,7 +23,7 @@ contains
 
     function alphabetize(lhs, rhs) result(first_alphabetically)
       character(len=*), intent(in) :: lhs, rhs
-      character(len=:), allocatable :: first_alphabetically
+      character(len=len(lhs)) :: first_alphabetically
       call assert(len(lhs)==len(rhs), "prif_co_min: LHS/RHS length match", lhs//" , "//rhs)
       first_alphabetically = min(lhs,rhs)
     end function

--- a/src/caffeine/collective_subroutines/co_reduce_s.f90
+++ b/src/caffeine/collective_subroutines/co_reduce_s.f90
@@ -50,7 +50,7 @@ submodule(prif:prif_private_s) co_reduce_s
       import c_char
       implicit none
       character(kind=c_char,len=*), intent(in) :: lhs, rhs
-      character(kind=c_char,len=:), allocatable :: lhs_op_rhs
+      character(kind=c_char,len=len(lhs)) :: lhs_op_rhs
     end function
 
     pure function c_float_complex_operation(lhs, rhs) result(lhs_op_rhs)

--- a/src/caffeine/collective_subroutines/co_reduce_s.f90
+++ b/src/caffeine/collective_subroutines/co_reduce_s.f90
@@ -260,7 +260,6 @@ contains
       type(c_ptr), value ::  cdata       !! Client data
 
       character(kind=c_char, len=:), allocatable, target :: prototype(:)
-      character(kind=c_char, len=:), pointer :: lhs(:)=>null(), rhs_and_result(:)=>null()
       integer(c_int), pointer :: arglen=>null()
 
       associate(c_associated_args => [c_associated(arg1), c_associated(arg2_and_out), c_associated(cdata)])
@@ -269,18 +268,19 @@ contains
 
       call c_f_pointer(cdata, arglen)
       allocate(character(kind=c_char, len=arglen) :: prototype(count))
-      lhs => prototype ! set string length
-      rhs_and_result => prototype ! set string length
-
-      call c_f_pointer(arg1, lhs, [count])
-      call c_f_pointer(arg2_and_out, rhs_and_result, [count])
-
       block
-        integer(c_size_t) i
+        character(kind=c_char, len=arglen), pointer :: lhs(:)=>null(), rhs_and_result(:)=>null()
 
-        do i=1, count
-          rhs_and_result(i) = char_op(lhs(i), rhs_and_result(i))
-        end do
+        call c_f_pointer(arg1, lhs, [count])
+        call c_f_pointer(arg2_and_out, rhs_and_result, [count])
+
+        block
+          integer(c_size_t) i
+
+          do i=1, count
+            rhs_and_result(i) = char_op(lhs(i), rhs_and_result(i))
+          end do
+        end block
       end block
 
     end subroutine

--- a/src/caffeine/collective_subroutines/co_reduce_s.f90
+++ b/src/caffeine/collective_subroutines/co_reduce_s.f90
@@ -259,7 +259,6 @@ contains
       integer(c_size_t), value :: count  !! Operand count
       type(c_ptr), value ::  cdata       !! Client data
 
-      character(kind=c_char, len=:), allocatable, target :: prototype(:)
       integer(c_int), pointer :: arglen=>null()
 
       associate(c_associated_args => [c_associated(arg1), c_associated(arg2_and_out), c_associated(cdata)])
@@ -267,7 +266,6 @@ contains
       end associate
 
       call c_f_pointer(cdata, arglen)
-      allocate(character(kind=c_char, len=arglen) :: prototype(count))
       block
         character(kind=c_char, len=arglen), pointer :: lhs(:)=>null(), rhs_and_result(:)=>null()
 

--- a/test/caf_co_max_test.f90
+++ b/test/caf_co_max_test.f90
@@ -124,8 +124,8 @@ contains
     function reverse_alphabetize_default_character_scalars() result(result_)
       type(result_t) result_
       integer, parameter :: length = len("loddy")
-      character(len=length), parameter :: words(*) = [character(len=length):: "loddy","doddy","we","like","to","party"]
-      character(len=:), allocatable :: my_word, expected_word
+      character(len=*), parameter :: words(*) = [character(len=length):: "loddy","doddy","we","like","to","party"]
+      character(len=len(words)) :: my_word, expected_word
       integer :: me, num_imgs
 
       call prif_this_image_no_coarray(this_image=me)
@@ -135,8 +135,7 @@ contains
       end associate
 
       call prif_num_images(num_imgs)
-      !expected_word = maxval(words(1:min(num_imgs, size(words)))) ! this line crashes flang
-      expected_word = "we"
+      expected_word = maxval(words(1:min(num_imgs, size(words))), dim=1)
       result_ = assert_equals(expected_word, my_word)
     end function
 

--- a/test/caf_co_min_test.f90
+++ b/test/caf_co_min_test.f90
@@ -108,12 +108,11 @@ contains
       character(len=*), parameter :: script(*) = &
         [character(len=len("the question.")) :: "To be ","or not"," to ","be.","  That is ","the question."]
       character(len=len(script)), dimension(3,2) :: scramlet, co_min_scramlet
-      integer i, cyclic_permutation(size(script))
+      integer i, cyclic_permutation(size(script)), me
 
-      associate(me => this_image())
-        associate(cyclic_permutation => [(1 + mod(i-1,size(script)), i=me, me+size(script) )])
-          scramlet = reshape(script(cyclic_permutation), shape(scramlet))
-        end associate
+      call prif_this_image_no_coarray(this_image=me)
+      associate(cyclic_permutation => [(1 + mod(i-1,size(script)), i=me, me+size(script) )])
+        scramlet = reshape(script(cyclic_permutation), shape(scramlet))
       end associate
 
       co_min_scramlet = scramlet
@@ -141,8 +140,9 @@ contains
 
     function alphabetically_1st_scalar_string() result(result_)
       type(result_t) result_
-      character(len=*), parameter :: words(*) = [character(len=len("to party!")):: "Loddy","doddy","we","like","to party!"]
-      character(len=:), allocatable :: my_word
+      integer, parameter :: length = len("to party!")
+      character(len=length), parameter :: words(*) = [character(len=length):: "Loddy","doddy","we","like","to party!"]
+      character(len=:), allocatable :: my_word, expected_word
       integer :: me, num_imgs
 
       call prif_this_image_no_coarray(this_image=me)
@@ -152,9 +152,9 @@ contains
       end associate
 
       call prif_num_images(num_images=num_imgs)
-      associate(expected_word => minval(words(1:min(num_imgs, size(words)))))
-        result_ = assert_equals(expected_word, my_word)
-      end associate
+      ! expected_word = minval(words(1:min(num_imgs, size(words)))) ! this line exposes a flang bug
+      expected_word = "Loddy"
+      result_ = assert_equals(expected_word, my_word)
     end function
 
 end module caf_co_min_test

--- a/test/caf_co_min_test.f90
+++ b/test/caf_co_min_test.f90
@@ -127,7 +127,7 @@ contains
       type(result_t) result_
       integer, parameter :: length = len("to party!")
       character(len=length), parameter :: words(*) = [character(len=length):: "Loddy","doddy","we","like","to party!"]
-      character(len=:), allocatable :: my_word, expected_word
+      character(len=length) :: my_word, expected_word
       integer :: me, num_imgs
 
       call prif_this_image_no_coarray(this_image=me)
@@ -137,8 +137,7 @@ contains
       end associate
 
       call prif_num_images(num_images=num_imgs)
-      ! expected_word = minval(words(1:min(num_imgs, size(words)))) ! this line exposes a flang bug
-      expected_word = "Loddy"
+      expected_word = minval(words(1:min(num_imgs, size(words))), dim=1)
       result_ = assert_equals(expected_word, my_word)
     end function
 

--- a/test/caf_co_reduce_test.f90
+++ b/test/caf_co_reduce_test.f90
@@ -30,6 +30,7 @@ contains
     type(result_t) result_
     character(len=*, kind=c_char), parameter :: names(*) = ["larry","harry","carey","betty","tommy","billy"]
     character(len=:, kind=c_char), allocatable :: my_name(:)
+    character(len=:), allocatable :: expected_name
     integer :: me, num_imgs
 
     call prif_this_image_no_coarray(this_image=me)
@@ -39,9 +40,9 @@ contains
     end associate
 
     call prif_num_images(num_images=num_imgs)
-    associate(expected_name => minval(names(1:min(num_imgs, size(names)))))
-      result_ = assert_that(all(expected_name == my_name))
-    end associate
+    !expected_name = minval(names(1:min(num_imgs, size(names)))) ! this exposes a flang bug
+    expected_name = "betty"
+    result_ = assert_that(all(expected_name == my_name))
 
   contains
 

--- a/test/caf_co_reduce_test.f90
+++ b/test/caf_co_reduce_test.f90
@@ -28,7 +28,7 @@ contains
 
   function alphabetically_1st_size1_string_array() result(result_)
     type(result_t) result_
-    character(len=*, kind=c_char), parameter :: names(*) = ["larry","harry","carey","betty","tommy","billy"]
+    character(len=5, kind=c_char), parameter :: names(*) = ["larry","harry","carey","betty","tommy","billy"]
     character(len=len(names), kind=c_char) :: my_name(1)
     character(len=len(names)) :: expected_name
     integer :: me, num_imgs
@@ -46,8 +46,8 @@ contains
   contains
 
     function alphabetize(lhs, rhs) result(first_alphabetically)
-      character(len=len(names)), intent(in) :: lhs, rhs
-      character(len=len(names)) :: first_alphabetically
+      character(len=5), intent(in) :: lhs, rhs
+      character(len=5) :: first_alphabetically
 
       first_alphabetically = min(lhs,rhs)
     end function


### PR DESCRIPTION
This PR 

1. Fixes a code conformance issue that flang identified.
2. Switches a `sync all` statement to `call prif_sync_all()`
3. Updates `install.sh` to add flags required for assumed-rank support if `llvm` is detected in `$FPM_CC --version`.

`fpm test` fails due to a code conformance problem in Veggies.  An issue will be submitted on the Veggies repository.