### PR TITLE
issue #101: Expand install.sh to allow passing configure options to GASNet

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -239,8 +239,8 @@ EOF
 fi
 
 PREFIX=${PREFIX:-"${HOME}/.local"}
-mkdir -p $PREFIX
-PREFIX=`$REALPATH $PREFIX`
+mkdir -p "$PREFIX"
+PREFIX=`$REALPATH "$PREFIX"`
 echo "PREFIX=$PREFIX"
 
 if [ -z ${PKG_CONFIG_PATH+x} ]; then


### PR DESCRIPTION
issue #101: Add pass-thru of install.sh arguments to GASNet configure

Now unrecognized install.sh arguments are assumed to be arguments for
GASNet-EX configure and passed through unchanged.

Users can alternatively pass GASNet configure arguments in shell
variable `$GASNET_CONFIGURE_ARGS`, which experience has shown can be
more convenient in some scripted packaging scenarios.

Fixes issue #101

In addition:

* Ensures that Caffeine-driven builds of GASNet always start with a
  clean GASNet build directory. Previously GASNet's config.cache was surviving
  into and affecting subsequent GASNet configure invocations on the
  same top-level Caffeine build dir.

* Updates the default GASNet configure arguments to select the GASNet
  config settings Caffeine requires, and disable unused features to save
  build time/space.

* Temporarily adds a GASNet configure argument to disable MPI
  interoperability support, which is mostly irrelevant for smp-conduit
  and just leads to confusing link-time errors with recent GASNet.
  We'll need to revisit this for expanding Caffeine's conduit support (issue #66)