### PR TITLE
Define feature-based macros for use via #include

### DIFF
--- a/include/language-support.F90
+++ b/include/language-support.F90
@@ -1,0 +1,23 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+
+#ifndef HAVE_SELECTED_LOGICAL_KIND
+  ! Define whether the compiler supports standard intrinsic function selected_logical_kind(), 
+  ! a feature introduced in Fortran 2023 clause 16.9.182.
+#if defined(_CRAYFTN) || defined(NAGFOR) || defined(__flang__)
+#define HAVE_SELECTED_LOGICAL_KIND 1
+#else
+#define HAVE_SELECTED_LOGICAL_KIND 0
+#endif  
+#endif
+
+#ifndef HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
+  ! Define whether the compiler supports associating a procedure pointer dummy argument with an
+  ! actual argument that is a valid target for the pointer dummy in a procedure assignment, a 
+  ! feature introduced in Fortran 2008 and described in Fortran 2023 clause 15.5.2.10 paragraph 5.
+#if defined(_CRAYFTN) || defined(__INTEL_COMPILER) || defined(NAGFOR) || defined(__flang__)
+#define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 1
+#else
+#define HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY 0
+#endif  
+#endif

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -1,5 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
+
+#include "language-support.F90"
+
 module prif
 
   use iso_c_binding, only: c_int, c_bool, c_intptr_t, c_intmax_t, c_ptr, c_funptr, c_size_t, c_ptrdiff_t, c_null_ptr
@@ -42,11 +45,12 @@ module prif
   integer(c_int), parameter, public :: PRIF_VERSION_MINOR = 4
 
   integer(c_int), parameter, public :: PRIF_ATOMIC_INT_KIND = selected_int_kind(18)
-  ! gfortran-14 doesn't currently support the intrinsic selected_logical_kind
-  ! The following commented-out definition is the desired definition and should replace
-  ! the temporary definition when possible
-  ! integer(c_int), parameter, public :: PRIF_ATOMIC_LOGICAL_KIND = selected_logical_kind(32)
+
+#if HAVE_SELECTED_LOGICAL_KIND
+  integer(c_int), parameter, public :: PRIF_ATOMIC_LOGICAL_KIND = selected_logical_kind(32)
+#else
   integer(c_int), parameter, public :: PRIF_ATOMIC_LOGICAL_KIND = PRIF_ATOMIC_INT_KIND
+#endif
 
   integer(c_int), parameter, public :: &
     PRIF_CURRENT_TEAM               = 101, &


### PR DESCRIPTION
This PR defines ceates a new `include/` subdirectory initially containing one `language-support.F90` file defining C-preprocessor macros defined around language feature support.  The two initial macros, `HAVE_SELECTED_LOGICAL_KIND` and `HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY`.  The `prif.f90` file now contains `#include "language-support.F90"` and uses the first of the two former macros.  The second macro is not currently used, but will be of use in the test suite if it is decided to switch to Julienne in the future.