### PR TITLE
Remove pure from `prif_error_stop` and update both `prif_error_stop` and `prif_stop` to support PRIF semantics

### DIFF
--- a/example/support-test/error_stop_with_integer_code.f90
+++ b/example/support-test/error_stop_with_integer_code.f90
@@ -8,9 +8,9 @@ program error_stop_with_integer_code
   implicit none
 
   integer init_exit_code
-  logical(kind=c_bool), parameter :: false = .false._c_bool
+  logical(kind=c_bool), parameter :: true = .true._c_bool
 
   call prif_init(init_exit_code)
-  call prif_error_stop(quiet=false, stop_code_int=expected_error_stop_code) ! a prif_error_stop unit test passes if this line executes error termination
-  call prif_stop(quiet=false) ! a prif_error_stop unit tests fails if this line runs
+  call prif_error_stop(quiet=true, stop_code_int=expected_error_stop_code) ! a prif_error_stop unit test passes if this line executes error termination
+  call prif_stop(quiet=true) ! a prif_error_stop unit tests fails if this line runs
 end program

--- a/example/support-test/error_stop_with_no_code.f90
+++ b/example/support-test/error_stop_with_no_code.f90
@@ -7,10 +7,10 @@ program error_stop_with_no_code
   implicit none
 
   integer init_exit_code
-  logical(kind=c_bool), parameter :: false = .false._c_bool
+  logical(kind=c_bool), parameter :: true = .true._c_bool
 
   call prif_init(init_exit_code)
-  call prif_error_stop(quiet=false) ! a prif_error_stop unit test passes if this line correctly executes error termination
-  call prif_stop(quiet=false) ! a prif_error_stop unit test fails if this line runs
+  call prif_error_stop(quiet=true) ! a prif_error_stop unit test passes if this line correctly executes error termination
+  call prif_stop(quiet=true) ! a prif_error_stop unit test fails if this line runs
      
 end program 

--- a/src/caffeine/prif_private_s.f90
+++ b/src/caffeine/prif_private_s.f90
@@ -9,7 +9,7 @@ submodule(prif) prif_private_s
 
   interface
 
-    pure module subroutine assert(assertion, description, diagnostics)
+    module subroutine assert(assertion, description, diagnostics)
       implicit none
       logical, intent(in) :: assertion
       character(len=*), intent(in) :: description

--- a/src/caffeine/program_termination.c
+++ b/src/caffeine/program_termination.c
@@ -1,5 +1,0 @@
-extern void inner_caf_error_stop_integer(void *);
-
-extern void caf_error_stop_integer_c(void *stop_code) {
-    inner_caf_error_stop_integer(stop_code);
-}

--- a/src/caffeine/program_termination.c
+++ b/src/caffeine/program_termination.c
@@ -1,9 +1,4 @@
-extern void inner_caf_error_stop_character(void *, int);
 extern void inner_caf_error_stop_integer(void *);
-
-extern void caf_error_stop_character_c(void *stop_code, int length) {
-    inner_caf_error_stop_character(stop_code, length);
-}
 
 extern void caf_error_stop_integer_c(void *stop_code) {
     inner_caf_error_stop_integer(stop_code);

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -110,28 +110,6 @@ contains
 
   end subroutine
 
-  function f_c_string(f_string) result(c_string)
-    character(len=*), intent(in) :: f_string
-    character(len=1,kind=c_char) :: c_string(len(f_string))
-
-    integer :: i
-
-    do concurrent (i = 1:len(f_string))
-      c_string(i) = f_string(i:i)
-    end do
-  end function
-
-  function c_f_string(c_string, length) result(f_string)
-    integer(c_int), intent(in) :: length
-    character(len=1,kind=c_char), intent(in) :: c_string(length)
-    character(len=length) :: f_string
-
-    integer :: i
-    do concurrent (i = 1:length)
-      f_string(i:i) = c_string(i)
-    end do
-  end function
-
   module procedure prif_fail_image
     call unimplemented("prif_fail_image")
   end procedure

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -26,8 +26,7 @@ contains
 
       call prif_sync_all
 
-      !write(output_unit, *) "caf_stop: stop code '", stop_code, "'"
-      write(output_unit, *) stop_code
+      write(output_unit, *) "STOP ", stop_code
       flush output_unit
 
       if (.not. present(stop_code)) call caf_decaffeinate(exit_code=0_c_int) ! does not return
@@ -41,7 +40,7 @@ contains
 
       call prif_sync_all
 
-      write(output_unit, *) "caf_stop: stop code '" // stop_code // "'"
+      write(output_unit, *) "STOP '" // stop_code // "'"
       flush output_unit
 
       call caf_decaffeinate(exit_code=0_c_int) ! does not return

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -65,30 +65,12 @@ contains
   subroutine prif_error_stop_character(stop_code)
     !! stop all images and provide the stop_code as the process exit status
     character(len=*), intent(in) :: stop_code
-
-    interface
-      subroutine caf_error_stop_character_c(stop_code, length) bind(C, name = "caf_error_stop_character_c")
-        use, intrinsic :: iso_c_binding, only: c_char, c_int
-        implicit none
-        integer(c_int), intent(in), value :: length
-        character(len=1,kind=c_char), intent(in) :: stop_code(length)
-      end subroutine
-    end interface
-
-    call caf_error_stop_character_c(f_c_string(stop_code), len(stop_code))
-  end subroutine
-
-  subroutine inner_caf_error_stop_character(stop_code, length) bind(C, name = "inner_caf_error_stop_character")
-    integer(c_int), intent(in) :: length
-    character(len=1,kind=c_char), intent(in) :: stop_code(length)
-
     integer(c_int), parameter :: error_occured = 1
 
-    write(error_unit, *) c_f_string(stop_code, length)
+    write(error_unit, *) stop_code
     flush error_unit
 
     call prif_error_stop_integer(error_occured)
-
   end subroutine
 
   subroutine prif_error_stop_integer(stop_code)

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -76,29 +76,11 @@ contains
   subroutine prif_error_stop_integer(stop_code)
     !! stop all images and provide the stop_code, or 0 if not present, as the process exit status
     integer, intent(in), optional :: stop_code
-
-    interface
-      subroutine caf_error_stop_integer_c(stop_code) bind(C, name = "caf_error_stop_integer_c")
-        use, intrinsic :: iso_c_binding, only: c_int
-        implicit none
-        integer(c_int), intent(in) :: stop_code
-      end subroutine
-    end interface
-
-    call caf_error_stop_integer_c(stop_code)
-  end subroutine
-
-  subroutine inner_caf_error_stop_integer(stop_code) bind(C, name = "inner_caf_error_stop_integer")
-    integer, intent(in), optional :: stop_code
-
     integer exit_code
 
     if (.not. present(stop_code)) then
-
       call caf_decaffeinate(exit_code=1)
-
     else if (stop_code==0) then
-
       write(error_unit) stop_code
       flush error_unit
       exit_code = 1
@@ -107,7 +89,6 @@ contains
     end if
 
     call caf_decaffeinate(exit_code) ! does not return
-
   end subroutine
 
   module procedure prif_fail_image

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -22,7 +22,7 @@ contains
 
     subroutine prif_stop_integer(stop_code)
       !! synchronize, stop the executing image, and provide the stop_code, or 0 if not present, as the process exit status
-      integer, intent(in), optional :: stop_code
+      integer(c_int), intent(in), optional :: stop_code
 
       call prif_sync_all
 
@@ -72,19 +72,23 @@ contains
   end subroutine
 
   subroutine prif_error_stop_integer(stop_code)
-    !! stop all images and provide the stop_code, or 0 if not present, as the process exit status
-    integer, intent(in), optional :: stop_code
-    integer exit_code
+    !! stop all images and provide the stop_code, or 1 if not present, as the process exit status
+    integer(c_int), intent(in), optional :: stop_code
+    integer(c_int) :: exit_code
 
-    if (.not. present(stop_code)) then
-      call caf_decaffeinate(exit_code=1)
-    else if (stop_code==0) then
-      write(error_unit) stop_code
-      flush error_unit
-      exit_code = 1
-    else
+    ! TODO: Resolve test issue - writing to the error_unit, which is the semantics of PRIF
+    ! breaks the current testing strategy for `prif_error_stop`
+    ! We plan to change the testing strategy anyway, so once this is done, need to comment back
+    ! in the code below related to the error_unit
+    if (present(stop_code)) then
+!      write(error_unit) "ERROR STOP ", stop_code
       exit_code = stop_code
+   else
+!      write(error_unit) "ERROR STOP"
+      exit_code = 1_c_int
     end if
+
+!    flush error_unit
 
     call caf_decaffeinate(exit_code) ! does not return
   end subroutine

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -64,12 +64,11 @@ contains
   subroutine prif_error_stop_character(stop_code)
     !! stop all images and provide the stop_code as the process exit status
     character(len=*), intent(in) :: stop_code
-    integer(c_int), parameter :: error_occured = 1
 
     write(error_unit, *) stop_code
     flush error_unit
 
-    call prif_error_stop_integer(error_occured)
+    call caf_decaffeinate(1_c_int) ! does not return
   end subroutine
 
   subroutine prif_error_stop_integer(stop_code)

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -75,7 +75,7 @@ contains
     character(len=*), intent(in) :: stop_code
 
     if (.not. quiet) then
-      write(error_unit, *) stop_code
+      write(error_unit, *) "ERROR STOP '" // stop_code // "'"
       flush error_unit
     end if
 

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -11,10 +11,8 @@ contains
 
     if (present(stop_code_char)) then
        call prif_stop_character(quiet, stop_code_char)
-    else if (present(stop_code_int)) then
-       call prif_stop_integer(quiet, stop_code_int)
     else
-       call prif_stop_integer(quiet)
+       call prif_stop_integer(quiet, stop_code_int)
     end if
 
   contains
@@ -66,10 +64,8 @@ contains
   module procedure prif_error_stop
     if (present(stop_code_char)) then
        call prif_error_stop_character(quiet, stop_code_char)
-    else if (present(stop_code_int)) then
-       call prif_error_stop_integer(quiet, stop_code_int)
     else
-       call prif_error_stop_integer(quiet)
+       call prif_error_stop_integer(quiet, stop_code_int)
     end if
   end procedure prif_error_stop
 

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -62,12 +62,12 @@ contains
     end if
   end procedure prif_error_stop
 
-  pure subroutine prif_error_stop_character(stop_code)
+  subroutine prif_error_stop_character(stop_code)
     !! stop all images and provide the stop_code as the process exit status
     character(len=*), intent(in) :: stop_code
 
     interface
-      pure subroutine caf_error_stop_character_c(stop_code, length) bind(C, name = "caf_error_stop_character_c")
+      subroutine caf_error_stop_character_c(stop_code, length) bind(C, name = "caf_error_stop_character_c")
         use, intrinsic :: iso_c_binding, only: c_char, c_int
         implicit none
         integer(c_int), intent(in), value :: length
@@ -91,12 +91,12 @@ contains
 
   end subroutine
 
-  pure subroutine prif_error_stop_integer(stop_code)
+  subroutine prif_error_stop_integer(stop_code)
     !! stop all images and provide the stop_code, or 0 if not present, as the process exit status
     integer, intent(in), optional :: stop_code
 
     interface
-      pure subroutine caf_error_stop_integer_c(stop_code) bind(C, name = "caf_error_stop_integer_c")
+      subroutine caf_error_stop_integer_c(stop_code) bind(C, name = "caf_error_stop_integer_c")
         use, intrinsic :: iso_c_binding, only: c_int
         implicit none
         integer(c_int), intent(in) :: stop_code
@@ -128,7 +128,7 @@ contains
 
   end subroutine
 
-  pure function f_c_string(f_string) result(c_string)
+  function f_c_string(f_string) result(c_string)
     character(len=*), intent(in) :: f_string
     character(len=1,kind=c_char) :: c_string(len(f_string))
 
@@ -139,7 +139,7 @@ contains
     end do
   end function
 
-  pure function c_f_string(c_string, length) result(f_string)
+  function c_f_string(c_string, length) result(f_string)
     integer(c_int), intent(in) :: length
     character(len=1,kind=c_char), intent(in) :: c_string(length)
     character(len=length) :: f_string

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -113,7 +113,7 @@ module prif
       character(len=*), intent(in), optional :: stop_code_char
     end subroutine
 
-    module pure subroutine prif_error_stop(quiet, stop_code_int, stop_code_char)
+    module subroutine prif_error_stop(quiet, stop_code_int, stop_code_char)
       implicit none
       logical(c_bool), intent(in) :: quiet
       integer(c_int), intent(in), optional :: stop_code_int


### PR DESCRIPTION
`prif_error_stop` in the PRIF spec is not `pure`. The caffeine implementation is `pure` since it was `pure` since before PRIF existed. This PR removes the `pure` attribute and makes the jump back and forth across Fortran and C in the implementation of `prif_error_stop` unnecessary, which caused a runtime error when trying to build with LLVM Flang. The jump back and forth across Fortran and C was necessary to obfuscate the non pure behavior (writing to the output_unit) inside of a procedure decorated with the `pure` attribute.

Also, update both `prif_error_stop` and `prif_stop` to support PRIF semantics, which includes implementing the `quiet` arg semantics.

Closes issue #77.
Closes issue #78.