### PR TITLE
Update README to remove notes about documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,6 @@ Dan Bonachea, Katherine Rasmussen, Brad Richardson, Damian Rouson.
 Lawrence Berkeley National Laboratory Technical Report (LBNL-2001636), Dec 2024.    
 <https://doi.org/10.25344/S4CG6G>
 
-Documentation
--------------
-One of our continuous integration (CI) scripts generates up-to-date Caffeine documentation using [ford].  The CI script also deploys the generated documentation to the our GitHub Pages [site].
-Alternatively, generate HTML documentation locally using [ford] as follows:
-```
-ford doc-generator.md
-```
-Open `doc/html/index.html` in a web browser.
-
 Funding
 -------
 The Computer Languages and Systems Software ([CLaSS]) Group at [Berkeley Lab] has developed Caffeine development on funding from the Exascale Computing Project ([ECP]) and the Stewardship for Programming Systems and Tools ([S4PST]) project. 


### PR DESCRIPTION
Update README to remove notes about documentation, as we want users to focus on the PRIF specification, which has much more useful content than the FORD docs do at this time