### PR TITLE
Fix issue #163

### DIFF
--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -106,13 +106,13 @@ contains
 
     if (present(stop_code)) then
       if (.not.quiet) then
-        write(error_unit) "ERROR STOP ", stop_code
+        write(error_unit,'(a)') "ERROR STOP ", stop_code
         flush error_unit
       end if
       exit_code = stop_code
     else
       if (.not.quiet) then
-        write(error_unit) "ERROR STOP"
+        write(error_unit,'(a)') "ERROR STOP"
         flush error_unit
       end if
       exit_code = 1_c_int

--- a/src/caffeine/program_termination_s.f90
+++ b/src/caffeine/program_termination_s.f90
@@ -106,7 +106,7 @@ contains
 
     if (present(stop_code)) then
       if (.not.quiet) then
-        write(error_unit,'(a)') "ERROR STOP ", stop_code
+        write(error_unit,'(A, I0)') "ERROR STOP ", stop_code
         flush error_unit
       end if
       exit_code = stop_code

--- a/test/caf_co_max_test.f90
+++ b/test/caf_co_max_test.f90
@@ -115,7 +115,7 @@ contains
 
       call prif_this_image_no_coarray(this_image=me)
       call prif_num_images(ni)
-      scramlet = script(:,:,mod(me,size(script,3))+1)
+      scramlet = script(:,:,mod(me-1,size(script,3))+1)
       call prif_co_max(scramlet)
       expected = maxval(script(:,:,1:min(ni,size(script,3))), dim=3)
       result_ = assert_that(all(expected == scramlet),"all(expected == scramlet)")

--- a/test/caf_co_max_test.f90
+++ b/test/caf_co_max_test.f90
@@ -104,21 +104,24 @@ contains
     function max_elements_in_2D_string_arrays() result(result_)
       type(result_t) result_
       character(len=*), parameter :: script(*,*,*) = reshape( &
-          [ "To be   ","or not  " &
-          , "to      ","be.     " &
-
-          , "that    ","is      " &
-          , "the     ","question"], &
+          [ "To be   ","or not  "   & ! images with odd image
+          , "to      ","be.     "   & ! numbers get this slice
+                                      ! ----------------------
+          , "that    ","is      "   & ! images with even image
+          , "the     ","question"], & ! numbers get this slice
           [2,2,2])
-      character(len=len(script)), dimension(size(script,1),size(script,2)) :: scramlet, expected
+      character(len=len(script)), dimension(size(script,1),size(script,2)) :: slice
       integer me, ni
 
       call prif_this_image_no_coarray(this_image=me)
       call prif_num_images(ni)
-      scramlet = script(:,:,mod(me-1,size(script,3))+1)
-      call prif_co_max(scramlet)
-      expected = maxval(script(:,:,1:min(ni,size(script,3))), dim=3)
-      result_ = assert_that(all(expected == scramlet),"all(expected == scramlet)")
+      associate(slice_number => mod(me-1,size(script,3)) + 1)
+        slice = script(:,:,slice_number)
+      end associate
+      call prif_co_max(slice)
+      associate(expected => maxval(script(:,:,1:min(ni,size(script,3))), dim=3))
+        result_ = assert_that(all(expected == slice),"all(expected == scramlet)")
+      end associate
     end function
 
     function reverse_alphabetize_default_character_scalars() result(result_)

--- a/test/caf_co_min_test.f90
+++ b/test/caf_co_min_test.f90
@@ -106,21 +106,24 @@ contains
     function min_elements_in_2D_string_arrays() result(result_)
       type(result_t) result_
       character(len=*), parameter :: script(*,*,*) = reshape( &
-          [ "To be   ","or not  " &
-          , "to      ","be.     " &
-
-          , "that    ","is      " &
-          , "the     ","question"], &
+          [ "To be   ","or not  "   & ! images with odd image
+          , "to      ","be.     "   & ! numbers get this slice
+                                      ! ----------------------
+          , "that    ","is      "   & ! images with even image
+          , "the     ","question"], & ! numbers get this slice
           [2,2,2])
-      character(len=len(script)), dimension(size(script,1),size(script,2)) :: scramlet, expected
+      character(len=len(script)), dimension(size(script,1),size(script,2)) :: slice
       integer me, ni
 
       call prif_this_image_no_coarray(this_image=me)
       call prif_num_images(ni)
-      scramlet = script(:,:,mod(me-1,size(script,3))+1)
-      call prif_co_min(scramlet)
-      expected = minval(script(:,:,1:min(ni,size(script,3))), dim=3)
-      result_ = assert_that(all(expected == scramlet),"all(expected == scramlet)")
+      associate(slice_number => mod(me-1,size(script,3)) + 1)
+        slice = script(:,:,slice_number)
+      end associate
+      call prif_co_min(slice)
+      associate(expected => minval(script(:,:,1:min(ni,size(script,3))), dim=3))
+        result_ = assert_that(all(expected == slice),"all(expected == scramlet)")
+      end associate
     end function
 
     function alphabetically_1st_scalar_string() result(result_)

--- a/test/caf_co_min_test.f90
+++ b/test/caf_co_min_test.f90
@@ -117,7 +117,7 @@ contains
 
       call prif_this_image_no_coarray(this_image=me)
       call prif_num_images(ni)
-      scramlet = script(:,:,mod(me,size(script,3))+1)
+      scramlet = script(:,:,mod(me-1,size(script,3))+1)
       call prif_co_min(scramlet)
       expected = minval(script(:,:,1:min(ni,size(script,3))), dim=3)
       result_ = assert_that(all(expected == scramlet),"all(expected == scramlet)")


### PR DESCRIPTION
This PR 
* Fixes an issue that caused test failures in single-image runs of the `prif_co_min` and `prif_co_max` tests,
* Adds clarifying comments in the `prif_co_min` and `prif_co_max` tests, and
* Adds a missing format in the `write` statement in `prif_stop_integer`.