### PR TITLE
Disable tests that are known to be broken with flang-new

### DIFF
--- a/test/main.F90
+++ b/test/main.F90
@@ -67,23 +67,36 @@ contains
         logical :: passed
 
         type(test_item_t) :: tests
-        type(test_item_t) :: individual_tests(15)
+        type(test_item_t), allocatable :: individual_tests(:)
 
-        individual_tests(1) = a00_caffeinate_caffeinate()
-        individual_tests(2) = caf_allocate_prif_allocate()
-        individual_tests(3) = caf_co_broadcast_prif_co_broadcast()
-        individual_tests(4) = caf_co_max_prif_co_max()
-        individual_tests(5) = caf_co_min_prif_co_min()
-        individual_tests(6) = caf_co_reduce_prif_co_reduce()
-        individual_tests(7) = caf_co_sum_prif_co_sum()
-        individual_tests(8) = caf_coarray_inquiry_coarray_inquiry()
-        individual_tests(9) = caf_error_stop_prif_this_image()
-        individual_tests(10) = caf_image_index_prif_image_index()
-        individual_tests(11) = caf_num_images_prif_num_images()
-        individual_tests(12) = caf_rma_prif_rma()
-        individual_tests(13) = caf_stop_prif_this_image()
-        individual_tests(14) = caf_teams_caf_teams()
-        individual_tests(15) = caf_this_image_prif_this_image_no_coarray()
+        allocate(individual_tests(0))
+
+#if __flang__
+        print *, "-----------------------------------------------------------------"
+        print *, "WARNING: flang-new compiler detected."
+        print *, "WARNING: Skipping tests that are known to fail with this compiler"
+        print *, "-----------------------------------------------------------------"
+#endif
+        individual_tests = [individual_tests, a00_caffeinate_caffeinate()]
+        individual_tests = [individual_tests, caf_allocate_prif_allocate()]
+        individual_tests = [individual_tests, caf_coarray_inquiry_coarray_inquiry()]
+        individual_tests = [individual_tests, caf_co_broadcast_prif_co_broadcast()]
+#if !__flang__
+        individual_tests = [individual_tests, caf_co_max_prif_co_max()]
+        individual_tests = [individual_tests, caf_co_min_prif_co_min()]
+        individual_tests = [individual_tests, caf_co_reduce_prif_co_reduce()]
+        individual_tests = [individual_tests, caf_co_sum_prif_co_sum()]
+        individual_tests = [individual_tests, caf_error_stop_prif_this_image()]
+#endif
+        individual_tests = [individual_tests, caf_image_index_prif_image_index()]
+        individual_tests = [individual_tests, caf_num_images_prif_num_images()]
+        individual_tests = [individual_tests, caf_rma_prif_rma()]
+#if !__flang__
+        individual_tests = [individual_tests, caf_stop_prif_this_image()]
+#endif
+        individual_tests = [individual_tests, caf_teams_caf_teams()]
+        individual_tests = [individual_tests, caf_this_image_prif_this_image_no_coarray()]
+
         tests = test_that(individual_tests)
 
 


### PR DESCRIPTION
With this change `run-fpm.sh test` now passes "out of the box" on a recent snapshot of flang-new, and prints a warning about skipping tests for features that are known to remain broken.

Support for flang-new remains in an experimental state, but this should help us avoid regressions on working functionality.

Example:
```
perlmutter$ flang-new --version
flang-new version 20.0.0git (git@github.com:llvm/llvm-project.git a4fdabeea997203edfe777c62c290c809217d0ac)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: [redacted]
Build config: +assertions

perlmutter$ env GASNET_PSHM_NODES=4 CC=clang CXX=clang++ FC=flang-new ./build/run-fpm.sh test 
Project is up to date
 -----------------------------------------------------------------
 WARNING: flang-new compiler detected.
 WARNING: Skipping tests that are known to fail with this compiler
 -----------------------------------------------------------------
Running Tests

Test that
    A caffeinated beverage
        is served: the prif_init() function completes successfully.
        a subsequent prif_init call returns PRIF_STAT_ALREADY_INIT
    PRIF allocation can
        allocate, use and deallocate an integer scalar coarray with a corank of 1
        allocate, use and deallocate memory non-symmetrically
    PRIF coarray inquiry functions
        prif_local_data_pointer
            returns the same pointer as when the coarray was allocated
    The prif_co_broadcast subroutine
        broadcasts a default integer scalar with no optional arguments present
        broadcasts a derived type scalar with no allocatable components
    prif_image_index
        returns 1 for the simplest case
        returns 1 when given the lower bounds
        returns 0 with invalid subscripts
        returns the expected answer for a more complicated case
    The prif_num_images function result
        is a valid number of images when invoked with no arguments
    PRIF RMA
        can send a value to another image
        can send a value with indirect interface
        can get a value from another image
        can get a value with indirect interface
    Teams
        can be created, changed to, and allocate coarrays
    The prif_this_image_no_coarray function result
        is the proper member of the set {1,2,...,num_images()} when invoked as this_image()

A total of 18 test cases

All Passed
All Passed
All Passed
All Passed
Took 0.115456 seconds
Took 0.115445 seconds
Took 0.115429 seconds
Took 0.115437 seconds




A total of 18 test cases containing a total of 43 assertions
A total of 18 test cases containing a total of 43 assertions
A total of 18 test cases containing a total of 43 assertions
A total of 18 test cases containing a total of 43 assertions




 STOP
 STOP
 STOP
 STOP
```

