### PR TITLE
CI: Always configure GASNet in `--enable-debug` mode

### DIFF
--- a/.github/workflows/build-with-flang.yml
+++ b/.github/workflows/build-with-flang.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       FC: flang-new
       CC: clang
+      GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
 
     steps:
     - name: Checkout code
@@ -38,4 +39,4 @@ jobs:
     - name: Run unit tests
       run: |
         export GASNET_PSHM_NODES=8
-        ./build/run-fpm.sh test -- -d
+        ./build/run-fpm.sh test --verbose -- -d

--- a/.github/workflows/build-with-flang.yml
+++ b/.github/workflows/build-with-flang.yml
@@ -27,13 +27,15 @@ jobs:
     - name: Build with LLVM Flang
       if: contains(matrix.os, 'ubuntu')
       run: |
+        set -x
+        apt update
+        apt install -y build-essential pkg-config make
+        echo == TOOL VERSIONS ==
         fpm --version
         $FC --version
         $CC --version
         export FPM_FC=$FC
         export FPM_CC=$CC
-        apt update
-        apt install -y build-essential pkg-config make
         ./install.sh
 
     - name: Run unit tests

--- a/.github/workflows/build-with-flang.yml
+++ b/.github/workflows/build-with-flang.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - uses: fortran-lang/setup-fpm@v4
+    - uses: fortran-lang/setup-fpm@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-with-flang.yml
+++ b/.github/workflows/build-with-flang.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 
 jobs:
-  Build:
+  flang-build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build-with-gfortran.yml
+++ b/.github/workflows/build-with-gfortran.yml
@@ -11,6 +11,7 @@ jobs:
 
     env:
       PREFIX: install
+      GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
 
     steps:
     - name: Checkout code
@@ -35,4 +36,4 @@ jobs:
     - name: Run unit tests
       run: |
         export GASNET_PSHM_NODES=8
-        ./build/run-fpm.sh test -- -d
+        ./build/run-fpm.sh test --verbose -- -d

--- a/.github/workflows/build-with-gfortran.yml
+++ b/.github/workflows/build-with-gfortran.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - uses: fortran-lang/setup-fpm@v6.0.1
+    - uses: fortran-lang/setup-fpm@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-with-gfortran.yml
+++ b/.github/workflows/build-with-gfortran.yml
@@ -24,13 +24,25 @@ jobs:
     - name: Install on Ubuntu
       if: contains(matrix.os, 'ubuntu')
       run: |
+        set -x
         sudo apt update
         sudo apt install -y build-essential gfortran-14 g++-14 pkg-config make
+        echo == TOOL VERSIONS ==
+        export GCC_VERSION=14
+        fpm --version
+        gfortran-${GCC_VERSION} --version
+        gcc-${GCC_VERSION} --version
         ./install.sh --prefix=${PREFIX}
 
     - name: Install on macOS
       if: contains(matrix.os, 'macos')
       run: |
+        set -x
+        echo == TOOL VERSIONS ==
+        export GCC_VERSION=14
+        fpm --version
+        gfortran-${GCC_VERSION} --version
+        gcc-${GCC_VERSION} --version
         ./install.sh --prefix=${PREFIX}
 
     - name: Run unit tests

--- a/.github/workflows/build-with-gfortran.yml
+++ b/.github/workflows/build-with-gfortran.yml
@@ -3,7 +3,7 @@ name: Build with gfortran
 on: [push, pull_request]
 
 jobs:
-  Build:
+  gfortran-build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Documentation
 on: [push, pull_request]
 
 jobs:
-  Build:
+  docs-build:
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Configuring GASNet in `--enable-debug` mode activates thousands of sanity-checking assertions inside libgasnet, which helps to detect usage violations from calls made by Caffeine.

Also enable fpm test verbosity to log compile commands.

Add a few other tangential CI improvements