### PR TITLE
Fix and re-enable stop and error stop tests for flang

### DIFF
--- a/.github/workflows/build-with-flang.yml
+++ b/.github/workflows/build-with-flang.yml
@@ -15,6 +15,7 @@ jobs:
       FC: flang-new
       CC: clang
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
+      SUBJOB_PREFIX: GASNET_PSHM_NODES=2
 
     steps:
     - name: Checkout code

--- a/src/caffeine/unit_test_parameters_m.F90
+++ b/src/caffeine/unit_test_parameters_m.F90
@@ -1,16 +1,45 @@
 ! Copyright (c), The Regents of the University
 ! Terms of use are as specified in LICENSE.txt
 module unit_test_parameters_m
-  !! Define values for consistent use throughout the test suite
+  use prif, only: prif_sync_all, prif_this_image_no_coarray
+  !! Define values and utilities for consistent use throughout the test suite
   implicit none
 
-  private
-  public :: expected_stop_code
-  public :: expected_error_stop_code
+  public
 
   enum, bind(C)
     enumerator :: expected_stop_code=99, expected_error_stop_code
       ! used in stop/error-stop unit tests and example/test-support supporting programs
   end enum
+
+  character(len=:), allocatable :: subjob_prefix
+
+contains
+
+  ! subjob support used by stop/error-stop unit tests
+  ! setup for subjob launch, initializes subjob_prefix and
+  ! returns whether this is the first image
+  function subjob_setup() result(result_)
+    character(len=*), parameter :: envvar = "SUBJOB_PREFIX"
+    logical :: result_
+    integer :: me, len
+    character :: dummy
+  
+    if (.not. allocated(subjob_prefix)) then
+      call get_environment_variable(envvar, dummy, len)
+      if (len > 0) then
+        allocate(character(len=len+1)::subjob_prefix)
+        call get_environment_variable(envvar, subjob_prefix, len)
+      else 
+        subjob_prefix = ""
+      endif
+      !print *,"SUBJOB_PREFIX='"//subjob_prefix//"' len=",len
+    end if
+        
+    call prif_sync_all()
+    call prif_this_image_no_coarray(this_image=me)
+    result_ = (me == 1)
+  end function 
+
 
 end module unit_test_parameters_m

--- a/test/main.F90
+++ b/test/main.F90
@@ -96,9 +96,7 @@ contains
         individual_tests = [individual_tests, test_prif_image_queries()]
         individual_tests = [individual_tests, caf_rma_prif_rma()]
         individual_tests = [individual_tests, test_prif_rma_strided()]
-#if !__flang__
         individual_tests = [individual_tests, caf_stop_prif_this_image()]
-#endif
         individual_tests = [individual_tests, caf_teams_caf_teams()]
         individual_tests = [individual_tests, caf_this_image_prif_this_image_no_coarray()]
 

--- a/test/main.F90
+++ b/test/main.F90
@@ -40,9 +40,6 @@ contains
         use caf_coarray_inquiry_test, only: &
                 caf_coarray_inquiry_coarray_inquiry => &
                     test_coarray_inquiry
-        use caf_error_stop_test, only: &
-                caf_error_stop_prif_this_image => &
-                    test_prif_this_image
         use caf_image_index_test, only: &
                 caf_image_index_prif_image_index => &
                     test_prif_image_index
@@ -55,15 +52,14 @@ contains
                     test_prif_rma
         use caf_strided_test, only: &
                     test_prif_rma_strided
-        use caf_stop_test, only: &
-                caf_stop_prif_this_image => &
-                    test_prif_this_image
         use caf_teams_test, only: &
                 caf_teams_caf_teams => &
                     test_caf_teams
         use caf_this_image_test, only: &
                 caf_this_image_prif_this_image_no_coarray => &
                     test_prif_this_image_no_coarray
+        use caf_stop_test, only: test_prif_stop
+        use caf_error_stop_test, only: test_prif_error_stop
         use veggies, only: test_item_t, test_that, run_tests
 
 
@@ -109,8 +105,8 @@ contains
         individual_tests = [individual_tests, test_prif_rma_strided()]
         individual_tests = [individual_tests, caf_teams_caf_teams()]
         individual_tests = [individual_tests, caf_this_image_prif_this_image_no_coarray()]
-        individual_tests = [individual_tests, caf_stop_prif_this_image()]
-        individual_tests = [individual_tests, caf_error_stop_prif_this_image()]
+        individual_tests = [individual_tests, test_prif_stop()]
+        individual_tests = [individual_tests, test_prif_error_stop()]
 
         tests = test_that(individual_tests)
 

--- a/test/main.F90
+++ b/test/main.F90
@@ -2,6 +2,7 @@
 ! DO NOT REGENERATE THIS FILE!
 program main
     use iso_c_binding, only : c_bool
+    use iso_fortran_env, only : OUTPUT_UNIT, ERROR_UNIT
     use prif, only : &
         prif_stop &
        ,prif_error_stop
@@ -75,10 +76,21 @@ contains
         allocate(individual_tests(0))
 
 #if __flang__
+    block
+        integer :: major, minor
+#     if defined(__flang_major__) && defined(__flang_minor__)
+        major = __flang_major__
+        minor = __flang_minor__
+#     else
+        major = -1
+        minor = -1
+#     endif
         print *, "-----------------------------------------------------------------"
-        print *, "WARNING: flang-new compiler detected."
+        print *, "WARNING: flang-new compiler detected, version:",major,".",minor
         print *, "WARNING: Skipping tests that are known to fail with this compiler"
         print *, "-----------------------------------------------------------------"
+        call flush(OUTPUT_UNIT)
+    end block
 #endif
         individual_tests = [individual_tests, a00_caffeinate_caffeinate()]
         individual_tests = [individual_tests, caf_allocate_prif_allocate()]
@@ -90,18 +102,20 @@ contains
         individual_tests = [individual_tests, caf_co_reduce_prif_co_reduce()]
         individual_tests = [individual_tests, caf_co_sum_prif_co_sum()]
 #endif
-        individual_tests = [individual_tests, caf_error_stop_prif_this_image()]
         individual_tests = [individual_tests, caf_image_index_prif_image_index()]
         individual_tests = [individual_tests, caf_num_images_prif_num_images()]
         individual_tests = [individual_tests, test_prif_image_queries()]
         individual_tests = [individual_tests, caf_rma_prif_rma()]
         individual_tests = [individual_tests, test_prif_rma_strided()]
-        individual_tests = [individual_tests, caf_stop_prif_this_image()]
         individual_tests = [individual_tests, caf_teams_caf_teams()]
         individual_tests = [individual_tests, caf_this_image_prif_this_image_no_coarray()]
+        individual_tests = [individual_tests, caf_stop_prif_this_image()]
+        individual_tests = [individual_tests, caf_error_stop_prif_this_image()]
 
         tests = test_that(individual_tests)
 
+        call flush(OUTPUT_UNIT)
+        call flush(ERROR_UNIT)
 
         passed = run_tests(tests)
 

--- a/test/main.F90
+++ b/test/main.F90
@@ -89,8 +89,8 @@ contains
         individual_tests = [individual_tests, caf_co_min_prif_co_min()]
         individual_tests = [individual_tests, caf_co_reduce_prif_co_reduce()]
         individual_tests = [individual_tests, caf_co_sum_prif_co_sum()]
-        individual_tests = [individual_tests, caf_error_stop_prif_this_image()]
 #endif
+        individual_tests = [individual_tests, caf_error_stop_prif_this_image()]
         individual_tests = [individual_tests, caf_image_index_prif_image_index()]
         individual_tests = [individual_tests, caf_num_images_prif_num_images()]
         individual_tests = [individual_tests, test_prif_image_queries()]

--- a/test/prif_error_stop_test.F90
+++ b/test/prif_error_stop_test.F90
@@ -33,7 +33,7 @@ contains
          ,cmdstat = command_status &
          ,cmdmsg = command_message &
         )   
-        result_ = assert_that(exit_status /= 0) .and. assert_equals(0, command_status, command_message)
+        result_ = assert_that(exit_status /= 0)
 
     end function
 
@@ -51,8 +51,7 @@ contains
          ,cmdmsg = command_message &
         )
         result_ = &
-         assert_equals(expected_error_stop_code, exit_status, "exit_status") &
-         .and. assert_equals(0, command_status, command_message)
+         assert_equals(expected_error_stop_code, exit_status, "exit_status") 
 
     end function
 
@@ -69,7 +68,7 @@ contains
          ,cmdstat = command_status &
          ,cmdmsg = command_message &
         )   
-        result_ = assert_that(exit_status /= 0) .and. assert_equals(0, command_status, command_message)
+        result_ = assert_that(exit_status /= 0)
 
     end function
 

--- a/test/prif_error_stop_test.F90
+++ b/test/prif_error_stop_test.F90
@@ -1,7 +1,8 @@
 module caf_error_stop_test
     use prif, only: prif_this_image_no_coarray, prif_sync_all
     use veggies, only: test_item_t, describe, result_t, it, assert_that, assert_equals, succeed
-    use unit_test_parameters_m, only : expected_error_stop_code
+    use unit_test_parameters_m, only : expected_error_stop_code, &
+        image_one => subjob_setup, cmd_prefix => subjob_prefix
 
     implicit none
     private
@@ -21,15 +22,6 @@ contains
                 ])
     end function
 
-    function image_one() result(result_)
-        logical :: result_
-        integer :: me
-
-        call prif_sync_all()
-        call prif_this_image_no_coarray(this_image=me)
-        result_ = (me == 1)
-    end function 
-
     function exit_with_no_stop_code() result(result_)
         type(result_t) :: result_
         integer exit_status
@@ -40,7 +32,7 @@ contains
         command_message = "exit_with_no_stop_code"
 
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example error_stop_with_no_code > /dev/null 2>&1" &
+          command = cmd_prefix//"./build/run-fpm.sh run --example error_stop_with_no_code > /dev/null 2>&1" &
          ,wait = .true. &
          ,exitstat = exit_status &
          ,cmdstat = command_status &
@@ -63,7 +55,7 @@ contains
         command_message = "exit_with_integer_stop_code"
 
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example error_stop_with_integer_code > /dev/null 2>&1" &
+          command = cmd_prefix//"./build/run-fpm.sh run --example error_stop_with_integer_code > /dev/null 2>&1" &
          ,wait = .true. &
          ,exitstat = exit_status &
          ,cmdstat = command_status &
@@ -87,7 +79,7 @@ contains
         command_message = "exit_with_character_stop_code"
 
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example error_stop_with_character_code > /dev/null 2>&1" &
+          command = cmd_prefix//"./build/run-fpm.sh run --example error_stop_with_character_code > /dev/null 2>&1" &
          ,wait = .true. &
          ,exitstat = exit_status &
          ,cmdstat = command_status &

--- a/test/prif_error_stop_test.F90
+++ b/test/prif_error_stop_test.F90
@@ -26,6 +26,8 @@ contains
         integer command_status
         character(len=max_message_len) command_message
 
+        command_message = "exit_with_no_stop_code"
+
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example error_stop_with_no_code > /dev/null 2>&1" &
          ,wait = .true. &
@@ -33,7 +35,7 @@ contains
          ,cmdstat = command_status &
          ,cmdmsg = command_message &
         )   
-        result_ = assert_that(exit_status /= 0)
+        result_ = assert_that(exit_status /= 0, command_message)
 
     end function
 
@@ -43,6 +45,8 @@ contains
         integer command_status
         character(len=max_message_len) command_message
 
+        command_message = "exit_with_integer_stop_code"
+
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example error_stop_with_integer_code > /dev/null 2>&1" &
          ,wait = .true. &
@@ -51,7 +55,7 @@ contains
          ,cmdmsg = command_message &
         )
         result_ = &
-         assert_equals(expected_error_stop_code, exit_status, "exit_status") 
+         assert_equals(expected_error_stop_code, exit_status, command_message) 
 
     end function
 
@@ -61,6 +65,8 @@ contains
         integer command_status
         character(len=max_message_len) command_message
 
+        command_message = "exit_with_character_stop_code"
+
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example error_stop_with_character_code > /dev/null 2>&1" &
          ,wait = .true. &
@@ -68,7 +74,7 @@ contains
          ,cmdstat = command_status &
          ,cmdmsg = command_message &
         )   
-        result_ = assert_that(exit_status /= 0)
+        result_ = assert_that(exit_status /= 0, command_message)
 
     end function
 

--- a/test/prif_stop_test.F90
+++ b/test/prif_stop_test.F90
@@ -1,15 +1,16 @@
 module caf_stop_test
-    use veggies, only: test_item_t, describe, result_t, it, assert_that, assert_equals
+    use prif, only: prif_this_image_no_coarray, prif_sync_all
+    use veggies, only: test_item_t, describe, result_t, it, assert_that, assert_equals, succeed
     use unit_test_parameters_m, only : expected_stop_code
 
     implicit none
     private
-    public :: test_prif_this_image
+    public :: test_prif_stop
 
    integer, parameter :: max_message_len = 128
 
 contains
-    function test_prif_this_image() result(tests)
+    function test_prif_stop() result(tests)
         type(test_item_t) :: tests
 
         tests = describe( &
@@ -21,11 +22,21 @@ contains
                 ])
     end function
 
+    function image_one() result(result_)
+        logical :: result_
+        integer :: me
+
+        call prif_sync_all()
+        call prif_this_image_no_coarray(this_image=me)
+        result_ = (me == 1)
+    end function 
+
     function exit_with_no_stop_code() result(result_)
         type(result_t) :: result_
         integer exit_status, cmd_stat
         character(len=max_message_len) command_message
 
+      if (image_one()) then
         command_message = "exit_with_no_stop_code"
 
         call execute_command_line( &
@@ -36,6 +47,9 @@ contains
           cmdmsg = command_message &
         )
         result_ = assert_equals(0, exit_status, command_message)
+      else
+        result_ = succeed("skipped")
+      end if
 
     end function
 
@@ -44,6 +58,7 @@ contains
         integer exit_status, cmd_stat
         character(len=max_message_len) command_message
 
+      if (image_one()) then
         command_message = "exit_with_integer_stop_code"
 
         call execute_command_line( &
@@ -54,6 +69,9 @@ contains
           cmdmsg = command_message &
         )
         result_ = assert_equals(expected_stop_code, exit_status, command_message)
+      else
+        result_ = succeed("skipped")
+      end if
 
     end function
 
@@ -62,6 +80,7 @@ contains
         integer exit_status, cmd_stat
         character(len=max_message_len) command_message
 
+      if (image_one()) then
         command_message = "exit_with_character_stop_code"
 
         call execute_command_line( &
@@ -73,6 +92,9 @@ contains
         )   
         ! the standard recommends zero exit status for character stop codes
         result_ = assert_equals(0, exit_status, command_message) 
+      else
+        result_ = succeed("skipped")
+      end if
 
     end function
 
@@ -81,6 +103,7 @@ contains
         integer exit_status, cmd_stat
         character(len=max_message_len) command_message
 
+      if (image_one()) then
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example register_stop_callback > /dev/null 2>&1", &
           wait = .true., &
@@ -89,6 +112,9 @@ contains
           cmdmsg = command_message &
         )
         result_ = assert_equals(0, exit_status, command_message)
+      else
+        result_ = succeed("skipped")
+      end if
     end function
 
 end module caf_stop_test

--- a/test/prif_stop_test.F90
+++ b/test/prif_stop_test.F90
@@ -21,12 +21,13 @@ contains
 
     function exit_with_no_stop_code() result(result_)
         type(result_t) :: result_
-        integer exit_status
+        integer exit_status, cmd_stat
 
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example stop_with_no_code > /dev/null 2>&1", &
           wait = .true., &
-          exitstat = exit_status &
+          exitstat = exit_status, &
+          cmdstat = cmd_stat &
         )
         result_ = assert_equals(0, exit_status)
 
@@ -34,12 +35,13 @@ contains
 
     function exit_with_integer_stop_code() result(result_)
         type(result_t) :: result_
-        integer exit_status
+        integer exit_status, cmd_stat
 
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example stop_with_integer_code > /dev/null 2>&1", &
           wait = .true., &
-          exitstat = exit_status &
+          exitstat = exit_status, &
+          cmdstat = cmd_stat &
         )
         result_ = assert_equals(expected_stop_code, exit_status)
 
@@ -47,12 +49,13 @@ contains
 
     function exit_with_character_stop_code() result(result_)
         type(result_t) :: result_
-        integer exit_status
+        integer exit_status, cmd_stat
 
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example stop_with_character_code > /dev/null 2>&1", &
           wait = .true., &
-          exitstat = exit_status &
+          exitstat = exit_status, &
+          cmdstat = cmd_stat &
         )   
         result_ = assert_equals(0, exit_status) ! the standard recommends zero exit status for character stop codes
 
@@ -61,12 +64,13 @@ contains
     function check_callback_invocation() result(result_)
       type(result_t) :: result_
 
-      integer :: exit_status
+      integer exit_status, cmd_stat
 
       call execute_command_line( &
         command = "./build/run-fpm.sh run --example register_stop_callback > /dev/null 2>&1", &
         wait = .true., &
-        exitstat = exit_status &
+        exitstat = exit_status, &
+        cmdstat = cmd_stat &
       )
       result_ = assert_equals(0, exit_status)
     end function

--- a/test/prif_stop_test.F90
+++ b/test/prif_stop_test.F90
@@ -1,7 +1,8 @@
 module caf_stop_test
     use prif, only: prif_this_image_no_coarray, prif_sync_all
     use veggies, only: test_item_t, describe, result_t, it, assert_that, assert_equals, succeed
-    use unit_test_parameters_m, only : expected_stop_code
+    use unit_test_parameters_m, only : expected_stop_code, &
+        image_one => subjob_setup, cmd_prefix => subjob_prefix
 
     implicit none
     private
@@ -22,15 +23,6 @@ contains
                 ])
     end function
 
-    function image_one() result(result_)
-        logical :: result_
-        integer :: me
-
-        call prif_sync_all()
-        call prif_this_image_no_coarray(this_image=me)
-        result_ = (me == 1)
-    end function 
-
     function exit_with_no_stop_code() result(result_)
         type(result_t) :: result_
         integer exit_status, cmd_stat
@@ -40,7 +32,7 @@ contains
         command_message = "exit_with_no_stop_code"
 
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example stop_with_no_code > /dev/null 2>&1", &
+          command = cmd_prefix//"./build/run-fpm.sh run --example stop_with_no_code > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
           cmdstat = cmd_stat, &
@@ -62,7 +54,7 @@ contains
         command_message = "exit_with_integer_stop_code"
 
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example stop_with_integer_code > /dev/null 2>&1", &
+          command = cmd_prefix//"./build/run-fpm.sh run --example stop_with_integer_code > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
           cmdstat = cmd_stat, &
@@ -84,7 +76,7 @@ contains
         command_message = "exit_with_character_stop_code"
 
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example stop_with_character_code > /dev/null 2>&1", &
+          command = cmd_prefix//"./build/run-fpm.sh run --example stop_with_character_code > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
           cmdstat = cmd_stat, &
@@ -105,7 +97,7 @@ contains
 
       if (image_one()) then
         call execute_command_line( &
-          command = "./build/run-fpm.sh run --example register_stop_callback > /dev/null 2>&1", &
+          command = cmd_prefix//"./build/run-fpm.sh run --example register_stop_callback > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
           cmdstat = cmd_stat, &

--- a/test/prif_stop_test.F90
+++ b/test/prif_stop_test.F90
@@ -6,6 +6,8 @@ module caf_stop_test
     private
     public :: test_prif_this_image
 
+   integer, parameter :: max_message_len = 128
+
 contains
     function test_prif_this_image() result(tests)
         type(test_item_t) :: tests
@@ -22,57 +24,71 @@ contains
     function exit_with_no_stop_code() result(result_)
         type(result_t) :: result_
         integer exit_status, cmd_stat
+        character(len=max_message_len) command_message
+
+        command_message = "exit_with_no_stop_code"
 
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example stop_with_no_code > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
-          cmdstat = cmd_stat &
+          cmdstat = cmd_stat, &
+          cmdmsg = command_message &
         )
-        result_ = assert_equals(0, exit_status)
+        result_ = assert_equals(0, exit_status, command_message)
 
     end function
 
     function exit_with_integer_stop_code() result(result_)
         type(result_t) :: result_
         integer exit_status, cmd_stat
+        character(len=max_message_len) command_message
+
+        command_message = "exit_with_integer_stop_code"
 
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example stop_with_integer_code > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
-          cmdstat = cmd_stat &
+          cmdstat = cmd_stat, &
+          cmdmsg = command_message &
         )
-        result_ = assert_equals(expected_stop_code, exit_status)
+        result_ = assert_equals(expected_stop_code, exit_status, command_message)
 
     end function
 
     function exit_with_character_stop_code() result(result_)
         type(result_t) :: result_
         integer exit_status, cmd_stat
+        character(len=max_message_len) command_message
+
+        command_message = "exit_with_character_stop_code"
 
         call execute_command_line( &
           command = "./build/run-fpm.sh run --example stop_with_character_code > /dev/null 2>&1", &
           wait = .true., &
           exitstat = exit_status, &
-          cmdstat = cmd_stat &
+          cmdstat = cmd_stat, &
+          cmdmsg = command_message &
         )   
-        result_ = assert_equals(0, exit_status) ! the standard recommends zero exit status for character stop codes
+        ! the standard recommends zero exit status for character stop codes
+        result_ = assert_equals(0, exit_status, command_message) 
 
     end function
 
     function check_callback_invocation() result(result_)
-      type(result_t) :: result_
+        type(result_t) :: result_
+        integer exit_status, cmd_stat
+        character(len=max_message_len) command_message
 
-      integer exit_status, cmd_stat
-
-      call execute_command_line( &
-        command = "./build/run-fpm.sh run --example register_stop_callback > /dev/null 2>&1", &
-        wait = .true., &
-        exitstat = exit_status, &
-        cmdstat = cmd_stat &
-      )
-      result_ = assert_equals(0, exit_status)
+        call execute_command_line( &
+          command = "./build/run-fpm.sh run --example register_stop_callback > /dev/null 2>&1", &
+          wait = .true., &
+          exitstat = exit_status, &
+          cmdstat = cmd_stat, &
+          cmdmsg = command_message &
+        )
+        result_ = assert_equals(0, exit_status, command_message)
     end function
 
 end module caf_stop_test


### PR DESCRIPTION
The stop and error stop tests were relying on some gfortran-specific behaviors for `execute_command_line` that are not guaranteed by the Fortran standard. Remove those gnu-isms and re-enable these tests for testing under flang.

These tests still remain horribly fragile for many reasons (issue #137), and addressing most of those problems are out-of-scope for this PR. However it was necessary to address problem 5 listed in issue #137 (subjob launch of a quadratic number of images) for these tests to pass at all in the flang github action container.

Passes on Perlmutter using both our amd-flang-20 and flang-21 snapshots.

