### PR TITLE
CI: Add run of some examples

### DIFF
--- a/.github/workflows/build-with-flang.yml
+++ b/.github/workflows/build-with-flang.yml
@@ -16,6 +16,7 @@ jobs:
       CC: clang
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
       SUBJOB_PREFIX: GASNET_PSHM_NODES=2
+      GASNET_PSHM_NODES: 8
 
     steps:
     - name: Checkout code
@@ -39,7 +40,15 @@ jobs:
         export FPM_CC=$CC
         ./install.sh
 
+    - name: Run examples
+      run: |
+        set -x
+        ./build/run-fpm.sh run --verbose --example hello
+        ./build/run-fpm.sh run --verbose --example stop_with_no_code
+        ( set +e ; ./build/run-fpm.sh run --verbose --example stop_with_integer_code ; test $? = 99 )
+        ( set +e ; ./build/run-fpm.sh run --verbose --example error_stop_with_integer_code ; test $? = 100 )
+
     - name: Run unit tests
       run: |
-        export GASNET_PSHM_NODES=8
+        set -x
         ./build/run-fpm.sh test --verbose -- -d

--- a/.github/workflows/build-with-gfortran.yml
+++ b/.github/workflows/build-with-gfortran.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       PREFIX: install
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
+      GASNET_PSHM_NODES: 8
 
     steps:
     - name: Checkout code
@@ -45,7 +46,15 @@ jobs:
         gcc-${GCC_VERSION} --version
         ./install.sh --prefix=${PREFIX}
 
+    - name: Run examples
+      run: |
+        set -x
+        ./build/run-fpm.sh run --verbose --example hello
+        ./build/run-fpm.sh run --verbose --example stop_with_no_code
+        ( set +e ; ./build/run-fpm.sh run --verbose --example stop_with_integer_code ; test $? = 99 )
+        ( set +e ; ./build/run-fpm.sh run --verbose --example error_stop_with_integer_code ; test $? = 100 )
+
     - name: Run unit tests
       run: |
-        export GASNET_PSHM_NODES=8
+        set -x
         ./build/run-fpm.sh test --verbose -- -d


### PR DESCRIPTION
This ensures our hello example gets coverage, and also establishes whether basic Caffeine functionality is working, separately from the veggies test harness.

Also separately run a few of the stop unit tests to validate exit code propagation.