### PR TITLE
fix #188: check for git in install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The `install.sh` script uses the following packages:
 * [pkg-config]
 * [realpath]
 * [make]
+* [git]
+* [curl]
 
 The script will invoke these if present in a user's `PATH`.
 If not present, the script will ask permission to use [Homebrew] to install the relevant package.
@@ -157,3 +159,6 @@ See [LICENSE.txt](LICENSE.txt) for usage terms and conditions.
 [pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
 [realpath]: https://man7.org/linux/man-pages/man3/realpath.3.html
 [make]: https://www.gnu.org/software/make/
+[git]: https://git-scm.com
+[curl]: https://curl.se
+

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,7 @@ the latest versions using Homebrew:
   GCC $GCC_VERSION
   GASNet-EX $GASNET_VERSION
   fpm
+  git (used by fpm to clone dependencies)
   pkg-config
   realpath (Homebrew coreutils)
   GNU Make (Homebrew coreutils)
@@ -118,6 +119,12 @@ fi
 
 if command -v fpm > /dev/null 2>&1; then
   FPM=`which fpm`
+fi
+
+if ! command -v git > /dev/null 2>&1; then
+  echo "git not found. Building Caffeine requires fpm, which uses git to install dependencies."
+  echo "Please install git, ensur it is in your PATH, and rerun ./install.sh"
+  exit 1
 fi
 
 ask_permission_to_use_homebrew()
@@ -198,7 +205,7 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
     exit_if_user_declines "brew"
 
     if ! command -v curl > /dev/null 2>&1; then
-      echo "No download mechanism found. Please install curl and rerun ./install.sh"
+      echo "curl not found. Please install curl, ensure it is in your PATH, and rerun ./install.sh"
       exit 1
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,7 @@ the latest versions using Homebrew:
   GASNet-EX $GASNET_VERSION
   fpm
   git (used by fpm to clone dependencies)
+  curl
   pkg-config
   realpath (Homebrew coreutils)
   GNU Make (Homebrew coreutils)
@@ -122,8 +123,13 @@ if command -v fpm > /dev/null 2>&1; then
 fi
 
 if ! command -v git > /dev/null 2>&1; then
-  echo "git not found. Building Caffeine requires fpm, which uses git to install dependencies."
-  echo "Please install git, ensur it is in your PATH, and rerun ./install.sh"
+  echo "git not found. Building Caffeine requires fpm, which uses git to download dependencies."
+  echo "Please install git, ensure it is in your PATH, and rerun ./install.sh"
+  exit 1
+fi
+
+if ! command -v curl > /dev/null 2>&1; then
+  echo "curl not found. Please install curl, ensure it is in your PATH, and rerun ./install.sh"
   exit 1
 fi
 
@@ -203,11 +209,6 @@ if [ -z ${FC+x} ] || [ -z ${CC+x} ] || [ -z ${CXX+x} ] || [ -z ${PKG_CONFIG+x} ]
 
     ask_permission_to_install_homebrew
     exit_if_user_declines "brew"
-
-    if ! command -v curl > /dev/null 2>&1; then
-      echo "curl not found. Please install curl, ensure it is in your PATH, and rerun ./install.sh"
-      exit 1
-    fi
 
     curl -L https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o $DEPENDENCIES_DIR/install-homebrew.sh --create-dirs
     chmod u+x $DEPENDENCIES_DIR/install-homebrew.sh


### PR DESCRIPTION
If the `install.sh` script can't execute `git`, the script will now print a message early requesting the user install `git`, after which the installer exits with non-zero status.