### PR TITLE
Post release chores

### DIFF
--- a/docs/README-release.md
+++ b/docs/README-release.md
@@ -26,12 +26,13 @@ Release Procedure for Caffeine
     4. Add/update list of high-level changes since last release
     5. Add/update list of known defects/limitations
     6. Spell-check and proofread
-6. Tag a release candidate and compel several people to manually validate it on
-    systems of interest. For example `git tag #.#.#-rc1`, then `git push origin #.#.#-rc1`
-7. Create annotated tag (only after release candidate has been checked by team members)
+6. Tag a release candidate. For example `git tag #.#.#-rc1`, then `git push origin #.#.#-rc1`
+7. Compel several people to manually validate the release candidate on systems of interest
+   and with compilers and compiler versions listed in README
+8. Create annotated tag (only after release candidate has been checked by team members)
     For example `git tag -a #.#.# -m "release version #.#.#"`, then `git push origin #.#.#`
-8. Publish the release
-9. Post release chores
+9. Publish the release
+10. Post release chores
     1. Git revert the commit that hardcoded the gasnet version or manually edit
     2. Update patch number of the version number embedded in:
        [manifest/fpm.toml.template](../manifest/fpm.toml.template), [install.sh](../install.sh)

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ EOF
 }
 
 GCC_VERSION=${GCC_VERSION:=14}
-GASNET_VERSION="2024.5.0"
+GASNET_VERSION="stable"
 
 list_prerequisites()
 {
@@ -402,7 +402,7 @@ CAFFEINE_FPM_CFLAGS=$GASNET_CFLAGS $GASNET_CPPFLAGS
 Name: caffeine
 Description: Coarray Fortran parallel runtime library
 URL: https://gitlab.lbl.gov/berkeleylab/caffeine
-Version: 0.5.0
+Version: 0.5.1
 EOF
 
 exit_if_pkg_config_pc_file_missing "caffeine"

--- a/manifest/fpm.toml.template
+++ b/manifest/fpm.toml.template
@@ -1,5 +1,5 @@
 name = "caffeine"
-version = "0.5.0"
+version = "0.5.1"
 license = "BSD-3-Clause-LBNL"
 author = ["Damian Rouson", "Brad Richardson", "Katherine Rasmussen", "Dan Bonachea"]
 maintainer = "fortran@lbl.gov"


### PR DESCRIPTION
- Post release chores
    - [x]  Git revert the commit that hardcoded the gasnet version or manually edit
    - [x]  Update patch number of the version number embedded in: [manifest/fpm.toml.template](https://github.com/BerkeleyLab/caffeine/blob/main/manifest/fpm.toml.template), [install.sh](https://github.com/BerkeleyLab/caffeine/blob/main/install.sh) Update to an odd number to indicate that the `main` branch is currently a snapshot of something that is beyond the offical release
    - [x]  Update the release procedure with any new steps or changes