### PR TITLE
Misc compiler warning fixes

### DIFF
--- a/src/caffeine/allocation_s.F90
+++ b/src/caffeine/allocation_s.F90
@@ -80,8 +80,8 @@ contains
     !   end subroutine
     ! end interface
     integer :: i, num_handles
-    integer(c_int) :: local_stat
-    character(len=:), allocatable :: local_errmsg
+    !integer(c_int) :: local_stat
+    !character(len=:), allocatable :: local_errmsg
     ! procedure(coarray_cleanup_i), pointer :: coarray_cleanup
     character(len=*), parameter :: unallocated_message = "Attempted to deallocate unallocated coarray"
 

--- a/src/caffeine/coarray_queries_s.F90
+++ b/src/caffeine/coarray_queries_s.F90
@@ -61,15 +61,15 @@ contains
     end do check_subscripts
 
     if (.not. invalid_cosubscripts) then
-      image_index = 1 + sub(1) - coarray_handle%info%lcobounds(1)
+      image_index = 1 + INT(sub(1) - coarray_handle%info%lcobounds(1), c_int)
       prior_size = 1
       ! Future work: values of prior_size are invariant across calls w/ the same coarray_handle
       !  We could store them in the coarray metadata at allocation rather than redundantly
       ! computing them here, which would accelerate calls with corank > 1 by removing
       ! corank multiply/add operations and the loop-carried dependence
       do dim = 2, size(sub)
-        prior_size = prior_size * (coarray_handle%info%ucobounds(dim-1) - coarray_handle%info%lcobounds(dim-1) + 1)
-        image_index = image_index + (sub(dim) - coarray_handle%info%lcobounds(dim)) * prior_size
+        prior_size = prior_size * INT(coarray_handle%info%ucobounds(dim-1) - coarray_handle%info%lcobounds(dim-1) + 1, c_int)
+        image_index = image_index + INT(sub(dim) - coarray_handle%info%lcobounds(dim), c_int) * prior_size
        end do
     end if
 

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -277,10 +277,7 @@ contains
     type(c_ptr), intent(in) :: ptr
     integer(c_intptr_t) :: as_int
 
-    ! the following snippet ensures at compile time that c_ptr and
-    ! c_intptr_t are actually the same size
-    integer, parameter :: int_ptr_check = merge(c_intptr_t, 0, storage_size(ptr) == storage_size(as_int))
-    integer(int_ptr_check), parameter :: unused = 0_int_ptr_check
+    call_assert(storage_size(ptr) == storage_size(as_int))
 
     as_int = transfer(ptr, as_int)
   end function

--- a/test/main.F90
+++ b/test/main.F90
@@ -88,7 +88,7 @@ contains
         call flush(OUTPUT_UNIT)
     end block
 #endif
-        individual_tests = [individual_tests, a00_caffeinate_caffeinate()]
+        individual_tests = [a00_caffeinate_caffeinate()]
         individual_tests = [individual_tests, caf_allocate_prif_allocate()]
         individual_tests = [individual_tests, caf_coarray_inquiry_coarray_inquiry()]
         individual_tests = [individual_tests, caf_co_broadcast_prif_co_broadcast()]

--- a/test/prif_this_image_test.F90
+++ b/test/prif_this_image_test.F90
@@ -10,8 +10,6 @@ contains
     function test_prif_this_image_no_coarray() result(tests)
         type(test_item_t) :: tests
     
-        integer, parameter :: initiation_success = 0
-
         tests = describe( &
           "The prif_this_image_no_coarray function result", &
           [ it("is the proper member of the set {1,2,...,num_images()} when invoked as this_image()", check_this_image_set) &
@@ -22,6 +20,8 @@ contains
         type(result_t) :: result_
         integer, allocatable :: image_numbers(:)
         integer i, me, ni
+
+        allocate(image_numbers(0))
 
         call prif_this_image_no_coarray(this_image=me)
         call prif_num_images(num_images=ni)


### PR DESCRIPTION
Fix some harmless but annoying compiler warnings throughout Caffeine encountered during development.

Here I'm deliberately ignoring the warnings currently issued by the collectives unit tests, which are resolved via complete rewrite in #158 