### PR TITLE
Implement context data and handle aliases

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -66,25 +66,25 @@ in the following sections.
 ---
 
 ## Storage Management
-### Support = partial (no support for coarray aliases)
+### Support = partial
 
 | Procedure | Status | Notes |
 |-----------|--------|-------|
 | `prif_allocate_coarray`    | **YES** |  |
-| `prif_allocate`    | **YES** |  |
-| `prif_deallocate_coarray`    | *partial* | no `final_func` arg support |
-| `prif_deallocate`    | **YES** |  |
-| `prif_alias_create`    | no |  |
-| `prif_alias_destroy`    | no |  |
+| `prif_allocate`            | **YES** |  |
+| `prif_deallocate_coarray`  | *partial* | no `final_func` arg support |
+| `prif_deallocate`          | **YES** |  |
+| `prif_alias_create`        | **YES** |  |
+| `prif_alias_destroy`       | **YES** |  |
 
 ---
 
 ## Coarray Queries
-### Support = partial (only support for `prif_image_index`)
+### Support = partial
 
 | Procedure | Status | Notes |
 |-----------|--------|-------|
-| `prif_set_context_data`, `prif_get_context_data` | no |  |
+| `prif_set_context_data`, `prif_get_context_data` | **YES** |  |
 | `prif_size_bytes`                                | **YES** |  |
 | `prif_lcobound_no_dim`, `prif_lcobound_with_dim` | **YES** |  |
 | `prif_ucobound_no_dim`, `prif_ucobound_with_dim` | **YES** |  |
@@ -129,7 +129,7 @@ in the following sections.
 ---
 
 ## SYNC Statements
-### Support = partial ( only support for `prif_sync_all`)
+### Support = partial
 
 | Procedure | Status | Notes |
 |-----------|--------|-------|

--- a/src/caffeine/alias_s.F90
+++ b/src/caffeine/alias_s.F90
@@ -4,6 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) alias_s
+  use iso_c_binding, only: &
+      c_null_funptr
 
   implicit none
 
@@ -12,13 +14,39 @@ contains
   module procedure prif_alias_create
     call_assert(coarray_handle_check(source_handle))
 
-    call unimplemented("prif_alias_create")
+    call_assert(size(alias_lcobounds) == size(alias_ucobounds))
+    call_assert(product(alias_ucobounds - alias_lcobounds + 1) >= current_team%info%num_images)
+
+    allocate(alias_handle%info)
+    ! start with a copy of the source descriptor
+    alias_handle%info = source_handle%info
+
+    ! apply provided cobounds
+    alias_handle%info%corank = size(alias_lcobounds)
+    alias_handle%info%lcobounds(1:size(alias_lcobounds)) = alias_lcobounds
+    alias_handle%info%ucobounds(1:size(alias_ucobounds)) = alias_ucobounds
+
+    ! reset some fields that are unused in aliases
+    alias_handle%info%reserved = c_null_ptr 
+    alias_handle%info%previous_handle = c_null_ptr
+    alias_handle%info%next_handle = c_null_ptr
+    alias_handle%info%final_func = c_null_funptr
+
+    call_assert(coarray_handle_check(alias_handle))
   end procedure
 
   module procedure prif_alias_destroy
+    type(prif_coarray_descriptor), pointer :: info 
+
     call_assert(coarray_handle_check(alias_handle))
 
-    call unimplemented("prif_alias_destroy")
+    info => alias_handle%info
+    call_assert(.not. c_associated(info%reserved))
+    call_assert(.not. c_associated(info%previous_handle))
+    call_assert(.not. c_associated(info%next_handle))
+    call_assert(.not. c_associated(info%final_func))
+
+    deallocate(info)
   end procedure
 
 end submodule alias_s

--- a/src/caffeine/allocation_s.F90
+++ b/src/caffeine/allocation_s.F90
@@ -54,6 +54,7 @@ contains
     coarray_handle%info%lcobounds(1:size(lcobounds)) = lcobounds
     coarray_handle%info%ucobounds(1:size(ucobounds)) = ucobounds
     call add_to_team_list(coarray_handle)
+    coarray_handle%info%p_context_data = c_loc(coarray_handle%info%reserved)
 
     allocated_memory = coarray_handle%info%coarray_data
     if (caf_have_child_teams()) then

--- a/src/caffeine/allocation_s.F90
+++ b/src/caffeine/allocation_s.F90
@@ -9,6 +9,7 @@ submodule(prif:prif_private_s) allocation_s
       c_f_pointer, &
       c_f_procpointer, &
       c_loc, &
+      c_null_ptr, &
       c_null_funptr
 
   implicit none
@@ -54,6 +55,7 @@ contains
     coarray_handle%info%lcobounds(1:size(lcobounds)) = lcobounds
     coarray_handle%info%ucobounds(1:size(ucobounds)) = ucobounds
     call add_to_team_list(coarray_handle)
+    coarray_handle%info%reserved = c_null_ptr
     coarray_handle%info%p_context_data = c_loc(coarray_handle%info%reserved)
 
     allocated_memory = coarray_handle%info%coarray_data

--- a/src/caffeine/allocation_s.F90
+++ b/src/caffeine/allocation_s.F90
@@ -9,7 +9,6 @@ submodule(prif:prif_private_s) allocation_s
       c_f_pointer, &
       c_f_procpointer, &
       c_loc, &
-      c_null_ptr, &
       c_null_funptr
 
   implicit none
@@ -26,6 +25,9 @@ contains
     integer(c_size_t) :: descriptor_size, total_size
     type(prif_coarray_descriptor) :: unused
     type(prif_coarray_descriptor), pointer :: unused2(:)
+
+    call_assert(size(lcobounds) == size(ucobounds))
+    call_assert(product(ucobounds - lcobounds + 1) >= current_team%info%num_images)
 
     me = current_team%info%this_image
     if (caf_have_child_teams()) then

--- a/src/caffeine/coarray_queries_s.F90
+++ b/src/caffeine/coarray_queries_s.F90
@@ -4,6 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) coarray_queries_s
+  use iso_c_binding, only: &
+      c_f_pointer
 
   implicit none
 
@@ -98,15 +100,19 @@ contains
   end procedure
 
   module procedure prif_set_context_data
+    type(c_ptr), pointer :: array_context_data
     call_assert(coarray_handle_check(coarray_handle))
 
-    call unimplemented("prif_set_context_data")
+    call c_f_pointer(coarray_handle%info%p_context_data, array_context_data)
+    array_context_data = context_data
   end procedure
 
   module procedure prif_get_context_data
+    type(c_ptr), pointer :: array_context_data
     call_assert(coarray_handle_check(coarray_handle))
 
-    call unimplemented("prif_get_context_data")
+    call c_f_pointer(coarray_handle%info%p_context_data, array_context_data)
+    context_data = array_context_data
   end procedure
 
   module procedure prif_size_bytes

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -1080,6 +1080,8 @@ module prif
     type(c_funptr) :: final_func
     type(c_ptr) :: previous_handle = c_null_ptr, next_handle = c_null_ptr
     integer(c_int64_t) :: lcobounds(15), ucobounds(15)
+    type(c_ptr) :: p_context_data
+    type(c_ptr) :: reserved
   end type
 
   type, private :: team_data

--- a/test/prif_allocate_test.F90
+++ b/test/prif_allocate_test.F90
@@ -141,7 +141,7 @@ contains
     type(result_t) :: result_
 
     ! Allocate memory for an integer scalar single corank coarray, such as the following decl
-    ! integer :: coarr(10)[4][*]
+    ! integer :: coarr(10)[4,*]
 
     integer(kind=c_int64_t), dimension(2) :: lcobounds, ucobounds
     integer :: dummy_element, num_imgs, i
@@ -171,9 +171,7 @@ contains
     call c_f_pointer(allocated_memory, local_slice, [10])
     result_ = result_ .and. assert_that(associated(local_slice))
 
-    do i = 1,10 
-      local_slice(i) = i*i
-    end do
+    local_slice = [(i*i, i = 1, 10)] 
     do i = 1,10 
       result_ = result_ .and. assert_equals(i*i, local_slice(i))
     end do

--- a/test/prif_allocate_test.F90
+++ b/test/prif_allocate_test.F90
@@ -3,8 +3,9 @@ module caf_allocate_test
       prif_allocate_coarray, prif_deallocate_coarray, &
       prif_allocate, prif_deallocate, &
       prif_coarray_handle, prif_num_images, prif_size_bytes, &
-      prif_set_context_data, prif_get_context_data
-  use veggies, only: result_t, test_item_t, assert_that, assert_equals, describe, it
+      prif_set_context_data, prif_get_context_data, prif_local_data_pointer, &
+      prif_alias_create, prif_alias_destroy
+  use veggies, only: result_t, test_item_t, assert_that, assert_equals, describe, it, succeed
   use iso_c_binding, only: &
       c_ptr, c_int, c_int64_t, c_size_t, c_funptr, c_null_funptr, &
       c_f_pointer, c_null_ptr, c_loc, c_sizeof, c_associated
@@ -96,6 +97,46 @@ contains
     call prif_deallocate(c_loc(local_slice))
   end function
 
+  function assert_aliased(h1, h2) result(result_)
+    type(result_t) :: result_
+    type(prif_coarray_handle) :: h1, h2
+    type(c_ptr) :: p1, p2
+    integer(c_size_t) :: s1, s2
+    type(c_ptr) :: c1, c2, cx
+    integer, save, target :: dummy(10)
+    integer, save :: di = 1
+
+    result_ = succeed("")
+
+    call prif_local_data_pointer(h1, p1)
+    call prif_local_data_pointer(h2, p2)
+    result_ = result_ .and. &
+      assert_that(c_associated(p1, p2))
+
+    call prif_size_bytes(h1, s1)
+    call prif_size_bytes(h2, s2)
+    result_ = result_ .and. &
+      assert_equals(int(s1), int(s2))
+
+    cx = c_loc(dummy(di))
+    di = mod(di,size(dummy)) + 1
+
+    call prif_set_context_data(h1, cx)
+    call prif_get_context_data(h1, c1)
+    result_ = result_ .and. &
+      assert_that(c_associated(c1, cx))
+
+    call prif_get_context_data(h2, c2)
+    result_ = result_ .and. &
+      assert_that(c_associated(c2, cx))
+
+    call prif_set_context_data(h2, c_null_ptr)
+    call prif_get_context_data(h1, c1)
+    result_ = result_ .and. &
+      assert_that(.not. c_associated(c1))
+
+  end function
+
   function check_allocate_integer_array_coarray_with_corank2() result(result_)
     type(result_t) :: result_
 
@@ -147,6 +188,36 @@ contains
         call prif_get_context_data(coarray_handle, actual)
         result_ = result_ .and. &
           assert_that(c_associated(expect, actual), "prif_{set,get}_context_data are working")
+      end do
+    end block
+
+    block ! check aliasing creation
+      integer i, j
+      integer, parameter :: lim = 10
+      type(prif_coarray_handle) :: a(lim)
+      integer(c_int64_t) :: lco(1), uco(1)
+      a(1) = coarray_handle
+      do i=2, lim
+        lco(1) = i
+        uco(1) = i + num_imgs
+        call prif_alias_create(a(i-1), lco, uco, a(i))
+        result_ = result_ .and. &
+          assert_aliased(a(i-1), a(i)) 
+        do j = i+1,lim
+          lco(1) = j
+          uco(1) = j + num_imgs
+          call prif_alias_create(a(i), lco, uco, a(j))
+          result_ = result_ .and. &
+            assert_aliased(a(i), a(j)) 
+          result_ = result_ .and. &
+            assert_aliased(a(j), coarray_handle) 
+        end do
+        do j = i+1,lim
+          call prif_alias_destroy(a(j))
+        end do
+      end do
+      do i=2, lim
+        call prif_alias_destroy(a(i))
       end do
     end block
 

--- a/test/prif_allocate_test.F90
+++ b/test/prif_allocate_test.F90
@@ -2,11 +2,12 @@ module caf_allocate_test
   use prif, only : &
       prif_allocate_coarray, prif_deallocate_coarray, &
       prif_allocate, prif_deallocate, &
-      prif_coarray_handle, prif_num_images, prif_size_bytes
+      prif_coarray_handle, prif_num_images, prif_size_bytes, &
+      prif_set_context_data, prif_get_context_data
   use veggies, only: result_t, test_item_t, assert_that, assert_equals, describe, it
   use iso_c_binding, only: &
       c_ptr, c_int, c_int64_t, c_size_t, c_funptr, c_null_funptr, &
-      c_f_pointer, c_null_ptr, c_loc, c_sizeof
+      c_f_pointer, c_null_ptr, c_loc, c_sizeof, c_associated
 
   implicit none
   private
@@ -21,6 +22,8 @@ contains
         "PRIF allocation can", &
         [ it("allocate, use and deallocate an integer scalar coarray with a corank of 1", &
               check_allocate_integer_scalar_coarray_with_corank1) &
+        , it("allocate, use and deallocate an integer array coarray with a corank of 2", &
+              check_allocate_integer_array_coarray_with_corank2) &
         , it("allocate, use and deallocate memory non-symmetrically", &
               check_allocate_non_symmetric) &
       ])
@@ -61,6 +64,19 @@ contains
     call prif_size_bytes(coarray_handle, data_size=query_size)
     result_ = result_ .and. assert_that(query_size == data_size, "prif_size_bytes is valid")
 
+    block ! Check prif_{set,get}_context_data
+      integer, target :: dummy(10), i
+      type(c_ptr) :: expect, actual
+      do i = 1,10 
+        expect = c_loc(dummy(i))
+        actual = c_null_ptr
+        call prif_set_context_data(coarray_handle, expect)
+        call prif_get_context_data(coarray_handle, actual)
+        result_ = result_ .and. &
+          assert_that(c_associated(expect, actual), "prif_{set,get}_context_data are working")
+      end do
+    end block
+
     call prif_deallocate_coarray([coarray_handle])
 
   end function
@@ -80,4 +96,61 @@ contains
     call prif_deallocate(c_loc(local_slice))
   end function
 
+  function check_allocate_integer_array_coarray_with_corank2() result(result_)
+    type(result_t) :: result_
+
+    ! Allocate memory for an integer scalar single corank coarray, such as the following decl
+    ! integer :: coarr(10)[4][*]
+
+    integer(kind=c_int64_t), dimension(2) :: lcobounds, ucobounds
+    integer :: dummy_element, num_imgs, i
+    type(prif_coarray_handle) :: coarray_handle
+    type(c_ptr) :: allocated_memory
+    integer, pointer :: local_slice(:)
+    integer(c_size_t) :: data_size, query_size
+
+    call prif_num_images(num_images=num_imgs)
+    lcobounds(1) = 1
+    ucobounds(1) = 4
+    lcobounds(2) = 1
+    ucobounds(2) = num_imgs
+
+    allocated_memory = c_null_ptr
+    local_slice => null()
+    result_ = assert_that(.not.associated(local_slice))
+
+    data_size = 10*storage_size(dummy_element)/8
+    call prif_allocate_coarray( &
+      lcobounds, ucobounds, data_size, c_null_funptr, &
+      coarray_handle, allocated_memory)
+
+    call prif_size_bytes(coarray_handle, data_size=query_size)
+    result_ = result_ .and. assert_that(query_size == data_size, "prif_size_bytes is valid")
+
+    call c_f_pointer(allocated_memory, local_slice, [10])
+    result_ = result_ .and. assert_that(associated(local_slice))
+
+    do i = 1,10 
+      local_slice(i) = i*i
+    end do
+    do i = 1,10 
+      result_ = result_ .and. assert_equals(i*i, local_slice(i))
+    end do
+
+    block ! Check prif_{set,get}_context_data
+      integer, target :: dummy(10), i
+      type(c_ptr) :: expect, actual
+      do i = 1,10 
+        expect = c_loc(dummy(i))
+        actual = c_null_ptr
+        call prif_set_context_data(coarray_handle, expect)
+        call prif_get_context_data(coarray_handle, actual)
+        result_ = result_ .and. &
+          assert_that(c_associated(expect, actual), "prif_{set,get}_context_data are working")
+      end do
+    end block
+
+    call prif_deallocate_coarray([coarray_handle])
+
+  end function
 end module caf_allocate_test

--- a/test/prif_image_index_test.F90
+++ b/test/prif_image_index_test.F90
@@ -24,11 +24,12 @@ contains
 
         type(prif_coarray_handle) :: coarray_handle
         type(c_ptr) :: allocated_memory
-        integer(c_int) :: answer
+        integer(c_int) :: answer, ni
+        call prif_num_images(num_images=ni)
 
         call prif_allocate_coarray( &
                 lcobounds = [1_c_int64_t], &
-                ucobounds = [2_c_int64_t], &
+                ucobounds = [ni+2_c_int64_t], &
                 size_in_bytes = 1_c_size_t, &
                 final_func = c_null_funptr, &
                 coarray_handle = coarray_handle, &
@@ -43,11 +44,12 @@ contains
 
         type(prif_coarray_handle) :: coarray_handle
         type(c_ptr) :: allocated_memory
-        integer(c_int) :: answer
+        integer(c_int) :: answer, ni
+        call prif_num_images(num_images=ni)
 
         call prif_allocate_coarray( &
                 lcobounds = [2_c_int64_t, 3_c_int64_t], &
-                ucobounds = [3_c_int64_t, 4_c_int64_t], &
+                ucobounds = [3_c_int64_t, ni+4_c_int64_t], &
                 size_in_bytes = 1_c_size_t, &
                 final_func = c_null_funptr, &
                 coarray_handle = coarray_handle, &
@@ -62,11 +64,12 @@ contains
 
         type(prif_coarray_handle) :: coarray_handle
         type(c_ptr) :: allocated_memory
-        integer(c_int) :: answer
+        integer(c_int) :: answer, ni
+        call prif_num_images(num_images=ni)
 
         call prif_allocate_coarray( &
                 lcobounds = [-2_c_int64_t, 2_c_int64_t], &
-                ucobounds = [2_c_int64_t, 6_c_int64_t], &
+                ucobounds = [2_c_int64_t, ni+6_c_int64_t], &
                 size_in_bytes = 1_c_size_t, &
                 final_func = c_null_funptr, &
                 coarray_handle = coarray_handle, &
@@ -82,11 +85,11 @@ contains
         type(prif_coarray_handle) :: coarray_handle
         type(c_ptr) :: allocated_memory
         integer(c_int) :: answer, ni
-
         call prif_num_images(num_images=ni)
+
         call prif_allocate_coarray( &
                 lcobounds = [1_c_int64_t, 2_c_int64_t], &
-                ucobounds = [2_c_int64_t, 3_c_int64_t], &
+                ucobounds = [2_c_int64_t, ni+3_c_int64_t], &
                 size_in_bytes = 1_c_size_t, &
                 final_func = c_null_funptr, &
                 coarray_handle = coarray_handle, &


### PR DESCRIPTION
This PR adds implementations for the following PRIF 0.5 interfaces:

* `prif_{set,get}_context_data`
* `prif_alias_{create,destroy}`

along with corresponding test code.

It also fixes some unreported latent defects in `prif_image_index_test` exposed by assertions added in `prif_allocate_coarray` to enforce PRIF preconditions.

