### PR TITLE
Update PRIF_VERSION_MINOR to 0.5

### DIFF
--- a/src/prif.F90
+++ b/src/prif.F90
@@ -47,7 +47,7 @@ module prif
   public :: prif_atomic_ref_int, prif_atomic_ref_int_indirect, prif_atomic_ref_logical, prif_atomic_ref_logical_indirect
 
   integer(c_int), parameter, public :: PRIF_VERSION_MAJOR = 0
-  integer(c_int), parameter, public :: PRIF_VERSION_MINOR = 4
+  integer(c_int), parameter, public :: PRIF_VERSION_MINOR = 5
 
   integer(c_int), parameter, public :: PRIF_ATOMIC_INT_KIND = selected_int_kind(18)
 


### PR DESCRIPTION
PR #158 brought the collectives interface into compliance with PRIF 0.5.

As such the prif.F90 provided by Caffeine is now believed to contain correct interfaces for every entry point specified in PRIF 0.5, and all are backed by linkable procedures.

Some procedures still throw an unimplemented error if invoked at runtime (see docs/implementation-status.md for the latest on implementation status), but the interfaces are complete.

Resolves issue #157