### PR TITLE
Hoist all use statements out of sub-submodules

### DIFF
--- a/src/caffeine/alias_s.F90
+++ b/src/caffeine/alias_s.F90
@@ -4,9 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) alias_s
-  use iso_c_binding, only: &
-      c_null_funptr
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/allocation_s.F90
+++ b/src/caffeine/allocation_s.F90
@@ -4,13 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) allocation_s
-  use iso_c_binding, only: &
-      c_sizeof, &
-      c_f_pointer, &
-      c_f_procpointer, &
-      c_loc, &
-      c_null_funptr
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/atomic_s.F90
+++ b/src/caffeine/atomic_s.F90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) atomic_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/co_broadcast_s.F90
+++ b/src/caffeine/co_broadcast_s.F90
@@ -4,7 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s)  co_broadcast_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/co_max_s.F90
+++ b/src/caffeine/co_max_s.F90
@@ -4,7 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) co_max_s
-  use iso_c_binding, only: c_loc, c_f_pointer
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/co_min_s.F90
+++ b/src/caffeine/co_min_s.F90
@@ -4,7 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) co_min_s
-  use iso_c_binding, only: c_loc, c_f_pointer
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/co_reduce_s.F90
+++ b/src/caffeine/co_reduce_s.F90
@@ -4,7 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) co_reduce_s
-  use iso_c_binding, only: c_funloc
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 contains
 

--- a/src/caffeine/co_sum_s.F90
+++ b/src/caffeine/co_sum_s.F90
@@ -4,7 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) co_sum_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/coarray_access_s.F90
+++ b/src/caffeine/coarray_access_s.F90
@@ -4,8 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) coarray_access_s
-  use iso_c_binding, only: c_loc
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/coarray_queries_s.F90
+++ b/src/caffeine/coarray_queries_s.F90
@@ -4,9 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) coarray_queries_s
-  use iso_c_binding, only: &
-      c_f_pointer
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/critical_s.F90
+++ b/src/caffeine/critical_s.F90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) critical_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/events_s.F90
+++ b/src/caffeine/events_s.F90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) events_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/image_queries_s.F90
+++ b/src/caffeine/image_queries_s.F90
@@ -4,7 +4,8 @@
 #include "assert_macros.h"
 
 submodule(prif:prif_private_s) image_queries_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/locks_s.F90
+++ b/src/caffeine/locks_s.F90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) locks_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -5,7 +5,22 @@
 
 submodule(prif) prif_private_s
   use assert_m
-  use iso_c_binding, only: c_associated
+
+  use iso_fortran_env, only : &
+        output_unit, &
+        error_unit
+
+  use iso_c_binding, only: &
+        c_associated, &
+        c_f_pointer, &
+        c_f_procpointer, &
+        c_funloc, &
+        c_loc, &
+        c_null_funptr, &
+        c_sizeof, &
+        ! DOB: The following is a gfortran-14 bug workaround. No idea why this works...
+        c_funptr_ => c_funptr
+
   implicit none
 
   type(team_data), target :: initial_team
@@ -40,7 +55,7 @@ submodule(prif) prif_private_s
 
     pure subroutine caf_fatal_error(str) bind(C)
       !! void caf_fatal_error( const CFI_cdesc_t* Fstr )
-      use iso_c_binding, only : c_char
+      import c_char
       implicit none
       character(kind=c_char,len=:), pointer, intent(in) :: str
     end subroutine

--- a/src/caffeine/program_startup_s.F90
+++ b/src/caffeine/program_startup_s.F90
@@ -1,6 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) program_startup_s
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 contains
 

--- a/src/caffeine/program_termination_s.F90
+++ b/src/caffeine/program_termination_s.F90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) program_termination_s
-  use iso_fortran_env, only : output_unit, error_unit
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
   type :: callback_entry

--- a/src/caffeine/sync_stmt_s.F90
+++ b/src/caffeine/sync_stmt_s.F90
@@ -1,7 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) sync_stmt_s
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 
 contains

--- a/src/caffeine/teams_s.F90
+++ b/src/caffeine/teams_s.F90
@@ -1,8 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(prif:prif_private_s) teams_s
-  use iso_c_binding, only: c_null_funptr, c_f_pointer, c_loc
-
+  ! DO NOT ADD USE STATEMENTS HERE
+  ! All use statements belong in prif_private_s.F90
   implicit none
 contains
 


### PR DESCRIPTION
use statements in a sub-submodule trigger pathological use conflicts in some compilers (gfortran) creating a maintenance headache.

Avoid this by hoisting all such use statements to the intermediate prif_private_s submodule.