### PR TITLE
Implement `prif_sync_images` 

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -129,14 +129,14 @@ in the following sections.
 ---
 
 ## SYNC Statements
-### Support = partial
+### Support = **YES**
 
 | Procedure | Status | Notes |
 |-----------|--------|-------|
-| `prif_sync_memory` | **YES**   |  |
-| `prif_sync_all`    | **YES**   |  |
-| `prif_sync_images` | no        |  |
-| `prif_sync_team`   | **YES**   |  |
+| `prif_sync_memory` | **YES** |  |
+| `prif_sync_all`    | **YES** |  |
+| `prif_sync_images` | **YES** |  |
+| `prif_sync_team`   | **YES** |  |
 
 ---
 

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -33,13 +33,28 @@ typedef uint8_t byte;
 static void event_init(void);
 
 // ---------------------------------------------------
-int caf_this_image(gex_TM_t gex_team)
-{
-  return gex_TM_QueryRank(gex_team) + 1;
+int caf_this_image(gex_TM_t tm) {
+  return gex_TM_QueryRank(tm) + 1;
 }
-int caf_num_images(gex_TM_t gex_team)
-{
-  return gex_TM_QuerySize(gex_team);
+int caf_num_images(gex_TM_t tm) {
+  return gex_TM_QuerySize(tm);
+}
+
+// Given team and corresponding image_num, return image number in the initial team
+int caf_image_to_initial(gex_TM_t tm, int image_num) {
+  assert(image_num >= 1);
+  assert(image_num <= gex_TM_QuerySize(tm));
+  gex_Rank_t proc = gex_TM_TranslateRankToJobrank(tm, image_num-1);
+  return proc + 1;
+}
+// Given image number in the initial team, return image number corresponding to given team
+int caf_image_from_initial(gex_TM_t tm, int image_num) {
+  assert(image_num >= 1);
+  assert(image_num <= numprocs);
+  gex_Rank_t proc = gex_TM_TranslateJobrankToRank(tm, image_num-1);
+  // GEX_RANK_INVALID indicates the provided image_num in initial team is not part of tm
+  assert(proc != GEX_RANK_INVALID); 
+  return proc + 1;
 }
 // ---------------------------------------------------
 // NOTE: gex_TM_T is a typedef to a C pointer, so the `gex_TM_t* initial_team` arg in the C signature matches the BIND(C) interface of an `intent(out)` arg of type `c_ptr` for the same argument

--- a/src/caffeine/caffeine.c
+++ b/src/caffeine/caffeine.c
@@ -221,7 +221,7 @@ static void event_init(void) {
   assert(event_AD != GEX_AD_INVALID);
 }
 
-void caf_event_post(int image, intptr_t event_var_ptr, int segment_boundary) {
+void caf_event_post(int image, intptr_t event_var_ptr, int segment_boundary, int release_fence) {
   assert(event_AD != GEX_AD_INVALID);
   assert(event_var_ptr);
 
@@ -232,7 +232,7 @@ void caf_event_post(int image, intptr_t event_var_ptr, int segment_boundary) {
   gex_AD_OpNBI_I64(event_AD, NULL, 
                    image-1, (void *)event_var_ptr, 
                    GEX_OP_INC, 0, 0, 
-                   GEX_FLAG_AD_REL);
+                   (release_fence ? GEX_FLAG_AD_REL : 0));
 
   // We've issued the post increment as an NBI operation,
   // allowing this call to return before the increment
@@ -252,7 +252,7 @@ void caf_event_query(void *event_var_ptr, int64_t *count) {
   );
 }
 
-void caf_event_wait(void *event_var_ptr, int64_t threshold, int segment_boundary) {
+void caf_event_wait(void *event_var_ptr, int64_t threshold, int segment_boundary, int acquire_fence) {
   assert(event_AD != GEX_AD_INVALID);
   assert(event_var_ptr);
   assert(threshold >= 1);
@@ -271,7 +271,7 @@ void caf_event_wait(void *event_var_ptr, int64_t threshold, int segment_boundary
     gex_AD_OpNB_I64(event_AD, &cnt, 
                     myproc, event_var_ptr,
                     GEX_OP_FSUB, threshold, 0,
-                    GEX_FLAG_AD_ACQ)
+                    (acquire_fence ? GEX_FLAG_AD_ACQ : 0))
   );
   assert(cnt >= threshold);
 }

--- a/src/caffeine/coarray_access_s.F90
+++ b/src/caffeine/coarray_access_s.F90
@@ -94,7 +94,8 @@ contains
         dest = remote_ptr, &
         src = current_image_buffer, &
         size = size_in_bytes)
-    call caf_event_post(image_num, notify_ptr, 0)
+    call caf_event_post(image_num, notify_ptr, &
+           segment_boundary=0, release_fence=1)
 
     if (present(stat)) stat = 0
   end procedure
@@ -326,7 +327,8 @@ contains
         element_size = element_size, &
         extent = extent, &
         stat = stat, errmsg = errmsg, errmsg_alloc = errmsg_alloc)
-    call caf_event_post(image_num, notify_ptr, 0)
+    call caf_event_post(image_num, notify_ptr, &
+           segment_boundary=0, release_fence=1)
   end procedure
 
 end submodule coarray_access_s

--- a/src/caffeine/events_s.F90
+++ b/src/caffeine/events_s.F90
@@ -26,7 +26,8 @@ contains
   module procedure prif_event_post_indirect
     call_assert_describe(image_num > 0 .and. image_num <= initial_team%num_images, "image_num not within valid range")
 
-    call caf_event_post(image_num, event_var_ptr, 1)
+    call caf_event_post(image_num, event_var_ptr, &
+           segment_boundary=1, release_fence=1)
 
     if (present(stat)) stat = 0
   end procedure
@@ -39,7 +40,8 @@ contains
     else
       threshold = 1
     endif
-    call caf_event_wait(event_var_ptr, threshold, 1)
+    call caf_event_wait(event_var_ptr, threshold, &
+           segment_boundary=1, acquire_fence=1)
 
     if (present(stat)) stat = 0
   end procedure
@@ -58,7 +60,8 @@ contains
     else
       threshold = 1
     endif
-    call caf_event_wait(notify_var_ptr, threshold, 0)
+    call caf_event_wait(notify_var_ptr, threshold, &
+           segment_boundary=0, acquire_fence=1)
 
     if (present(stat)) stat = 0
   end procedure

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -194,22 +194,24 @@ submodule(prif) prif_private_s
     end subroutine
 
     ! _______________________ Events  ____________________________
-    subroutine caf_event_post(image, event_var_ptr, segment_boundary) bind(c)
-      !! void caf_event_post(int image, intptr_t event_var_ptr, int segment_boundary)
+    subroutine caf_event_post(image, event_var_ptr, segment_boundary, release_fence) bind(c)
+      !! void caf_event_post(int image, intptr_t event_var_ptr, int segment_boundary, int release_fence)
       import c_int, c_intptr_t
       implicit none
       integer(c_int), intent(in), value :: image
       integer(c_intptr_t), intent(in), value :: event_var_ptr
       integer(c_int), intent(in), value :: segment_boundary
+      integer(c_int), intent(in), value :: release_fence
     end subroutine
 
-    subroutine caf_event_wait(event_var_ptr, threshold, segment_boundary) bind(c)
-      !! void caf_event_wait(void *event_var_ptr, int64_t threshold, int segment_boundary)
+    subroutine caf_event_wait(event_var_ptr, threshold, segment_boundary, acquire_fence) bind(c)
+      !! void caf_event_wait(void *event_var_ptr, int64_t threshold, int segment_boundary, int acquire_fence)
       import c_int64_t, c_ptr, c_int
       implicit none
       type(c_ptr), intent(in), value :: event_var_ptr
       integer(c_int64_t), intent(in), value :: threshold
       integer(c_int), intent(in), value :: segment_boundary
+      integer(c_int), intent(in), value :: acquire_fence
     end subroutine
 
     subroutine caf_event_query(event_var_ptr, count) bind(c)

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -77,6 +77,24 @@ submodule(prif) prif_private_s
       integer(c_int) caf_num_images
     end function
 
+    function caf_image_to_initial(gex_team, image_num) bind(C)
+      !! int caf_image_to_initial(gex_TM_t tm, int image_num)
+      import c_ptr, c_int
+      implicit none
+      type(c_ptr), value :: gex_team
+      integer(c_int), value :: image_num
+      integer(c_int) caf_image_to_initial
+    end function
+
+    function caf_image_from_initial(gex_team, image_num) bind(C)
+      !! int caf_image_from_initial(gex_TM_t tm, int image_num)
+      import c_ptr, c_int
+      implicit none
+      type(c_ptr), value :: gex_team
+      integer(c_int), value :: image_num
+      integer(c_int) caf_image_from_initial
+    end function
+
     ! _________________ Memory allocation ____________________
 
     function caf_allocate(mspace, bytes) result(ptr) bind(c)

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -200,6 +200,9 @@ submodule(prif) prif_private_s
 
     ! __________________ SYNC Statements _____________________
 
+    module subroutine sync_init()
+    end subroutine
+
     subroutine caf_sync_memory() bind(C)
       !! void caf_sync_memory();
     end subroutine

--- a/src/caffeine/program_startup_s.F90
+++ b/src/caffeine/program_startup_s.F90
@@ -24,6 +24,9 @@ contains
        initial_team%team_number = -1
        initial_team%this_image = caf_this_image(initial_team%gex_team)
        initial_team%num_images = caf_num_images(initial_team%gex_team)
+
+       call sync_init()
+
        prif_init_called_previously = .true.
        stat = 0
     end if

--- a/src/caffeine/sync_stmt_s.F90
+++ b/src/caffeine/sync_stmt_s.F90
@@ -1,19 +1,23 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
+
+#include "assert_macros.h"
+
 submodule(prif:prif_private_s) sync_stmt_s
   ! DO NOT ADD USE STATEMENTS HERE
   ! All use statements belong in prif_private_s.F90
   implicit none
+
+  ! Data structures used to implement prif_sync_images
+  type(prif_coarray_handle) :: si_coarray_handle
+  type(prif_event_type), pointer :: si_evt(:)
+  integer(c_size_t) :: sizeof_event
 
 contains
 
   module procedure prif_sync_all
     call caf_sync_team(current_team%info%gex_team)
     if (present(stat)) stat = 0
-  end procedure
-
-  module procedure prif_sync_images
-    call unimplemented("prif_sync_images")
   end procedure
 
   module procedure prif_sync_team
@@ -24,6 +28,91 @@ contains
   module procedure prif_sync_memory
     call caf_sync_memory
     if (present(stat)) stat = 0
+  end procedure
+
+  module procedure sync_init
+    ! Create the array coarray used to implement prif_sync_images
+    ! This following is effectively: 
+    !   type(EVENT_TYPE), allocatable :: si_evt(:)[*]
+    !   ALLOCATE( si_evt(NUM_IMAGES()) )
+    type(prif_event_type) :: dummy_event
+    type(c_ptr) :: allocated_memory
+
+    associate(num_imgs => initial_team%num_images) 
+
+      sizeof_event = int(storage_size(dummy_event)/8, c_size_t)
+
+      call prif_allocate_coarray( &
+            lcobounds = [1_c_int64_t], &
+            ucobounds = [int(num_imgs,c_int64_t)], &
+            size_in_bytes = sizeof_event * num_imgs, &
+            final_func = c_null_funptr, &
+            coarray_handle = si_coarray_handle, &
+            allocated_memory = allocated_memory)
+      call c_f_pointer(allocated_memory, si_evt, [num_imgs])
+      si_evt = dummy_event ! default initialize
+
+   end associate
+    
+  end procedure
+
+  module procedure prif_sync_images
+    integer(c_int) :: i, img, l, u
+    integer(c_intptr_t) :: evt_ptr
+
+    call_assert(coarray_handle_check(si_coarray_handle))
+
+    call caf_sync_memory ! end segment and amortize release fence
+
+    associate(num_imgs => current_team%info%num_images) 
+      if (present(image_set)) then
+        l = lbound(image_set,1)
+        u = ubound(image_set,1)
+#       if ASSERTIONS
+          block ! input validation
+            logical p(num_imgs)
+            p = .false.
+            do i = l,u
+              call_assert(image_set(i) >= 1 .and. image_set(i) <= num_imgs)
+              call_assert_describe(.not. p(image_set(i)), "image indices in SYNC IMAGES are not distinct!")
+              p(image_set(i)) = .true.
+            end do
+          end block
+#       endif
+      else ! SYNC IMAGES (*)
+        l = 1
+        u = num_imgs
+      endif
+    end associate
+
+    ! post an event to each peer in my slot
+    do i=l,u
+      if (present(image_set)) then
+        img = image_set(i)
+      else
+        img = i
+      endif
+      img = caf_image_to_initial( current_team%info%gex_team, img )
+      call base_pointer(si_coarray_handle, img, evt_ptr)
+      evt_ptr = evt_ptr + sizeof_event * (initial_team%this_image - 1)
+      call caf_event_post(img, evt_ptr, &
+                          segment_boundary=0, release_fence=0)
+    end do
+
+    ! reap an event from each peer in its slot
+    ! final iteration issues acquire fence
+    do i=l,u
+      if (present(image_set)) then
+        img = image_set(i)
+      else
+        img = i
+      endif
+      img = caf_image_to_initial( current_team%info%gex_team, img )
+      call caf_event_wait(c_loc(si_evt(img)), 1_c_int64_t, &
+                          segment_boundary=0, &
+                          acquire_fence=merge(1,0,i==u))
+    end do
+
   end procedure
 
 end submodule

--- a/test/main.F90
+++ b/test/main.F90
@@ -47,6 +47,7 @@ contains
                 caf_num_images_prif_num_images => &
                     test_prif_num_images
         use caf_image_queries_test, only: test_prif_image_queries
+        use caf_sync_images_test, only: test_prif_sync_images
         use caf_rma_test, only: &
                 caf_rma_prif_rma => &
                     test_prif_rma
@@ -106,6 +107,7 @@ contains
         individual_tests = [individual_tests, caf_teams_caf_teams()]
         individual_tests = [individual_tests, caf_this_image_prif_this_image_no_coarray()]
         individual_tests = [individual_tests, test_prif_event()]
+        individual_tests = [individual_tests, test_prif_sync_images()]
         individual_tests = [individual_tests, test_prif_stop()]
         individual_tests = [individual_tests, test_prif_error_stop()]
 

--- a/test/prif_sync_images_test.F90
+++ b/test/prif_sync_images_test.F90
@@ -1,0 +1,94 @@
+module caf_sync_images_test
+    use iso_c_binding, only: c_int
+    use prif, only : prif_sync_images, prif_this_image_no_coarray, prif_num_images, prif_sync_all
+    use veggies, only: result_t, test_item_t, assert_that, describe, it, succeed
+
+    implicit none
+    private
+    public :: test_prif_sync_images
+
+    integer, parameter :: lim = 10
+
+contains
+    function test_prif_sync_images() result(tests)
+        type(test_item_t) :: tests
+    
+        tests = describe( &
+          "PRIF sync images", [ &
+           it("pass serial prif_sync_images test", check_serial), &
+           it("pass prif_sync_images neighbor test", check_neighbor), &
+           it("pass prif_sync_images hot-spot test", check_hot) &
+        ])
+    end function
+
+    function check_serial() result(result_)
+        type(result_t) :: result_
+        integer(c_int) :: me
+        integer :: i
+
+        call prif_this_image_no_coarray(this_image=me)
+        call prif_sync_all
+       
+        ! synchronize with myself an image-dependent number of times:
+        do i=1, lim*me
+          call prif_sync_images([me])
+        end do
+
+        call prif_sync_all
+        result_ = succeed("")
+    end function
+
+
+    function check_neighbor() result(result_)
+        type(result_t) :: result_
+        integer(c_int) :: me, num_imgs
+        integer :: i
+
+        call prif_this_image_no_coarray(this_image=me)
+        call prif_num_images(num_images=num_imgs)
+        call prif_sync_all
+       
+        ! test based on F23 11.7.4 note 3
+        do i=1, lim
+          if (me > 1)        call prif_sync_images([me-1])
+          if (me < num_imgs) call prif_sync_images([me+1])
+        end do
+
+        call prif_sync_all
+        result_ = succeed("")
+    end function
+
+    function check_hot() result(result_)
+        type(result_t) :: result_
+        integer(c_int) :: me, num_imgs
+        integer :: i
+
+        call prif_this_image_no_coarray(this_image=me)
+        call prif_num_images(num_images=num_imgs)
+        call prif_sync_all
+       
+        ! all images synchronize with 1
+        if (me == 1) then
+          block
+            integer(c_int) :: everyone(num_imgs)
+            everyone = [(i, i=1,num_imgs)]
+            do i=1, lim
+              ! SYNC IMAGES (*)
+              call prif_sync_images()
+            end do
+            do i=1, lim
+              call prif_sync_images(everyone)
+            end do
+          end block
+        else
+          do i=1, lim*2
+            call prif_sync_images([1])
+          end do
+        endif
+
+        call prif_sync_all
+        result_ = succeed("")
+    end function
+
+
+end module 


### PR DESCRIPTION
Implement `prif_sync_images`, using a straightforward (non-scalable) event-based algorithm.
Given the `SYNC IMAGES` language feature itself is fundamentally non-scalable, this seems like a reasonable near-term implementation.

This PR critically depends upon PR #212, which should be reviewed & merged first.

Fixes #216