### PR TITLE
Support installation with Homebrew-installed LLVM 20

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -416,9 +416,11 @@ exit_if_pkg_config_pc_file_missing "caffeine"
 user_compiler_flags="${CPPFLAGS:-} ${FFLAGS:-}"
 
 compiler_version=$($FPM_FC --version)
-if [[ $compiler_version == flang* ]]; then
+if [[ $compiler_version == *flang* ]]; then
+  echo "--------> flang"
   compiler_flag="-g -O3"
 else # assume gfortran
+  echo "--------> assume gfortran"
   compiler_flag="-g -O3 -ffree-line-length-0 -Wno-unused-dummy-argument"
 fi
 compiler_flag+=" -DASSERT_MULTI_IMAGE -DASSERT_PARALLEL_CALLBACKS"

--- a/install.sh
+++ b/install.sh
@@ -417,10 +417,8 @@ user_compiler_flags="${CPPFLAGS:-} ${FFLAGS:-}"
 
 compiler_version=$($FPM_FC --version)
 if [[ $compiler_version == *flang* ]]; then
-  echo "--------> flang"
   compiler_flag="-g -O3"
 else # assume gfortran
-  echo "--------> assume gfortran"
   compiler_flag="-g -O3 -ffree-line-length-0 -Wno-unused-dummy-argument"
 fi
 compiler_flag+=" -DASSERT_MULTI_IMAGE -DASSERT_PARALLEL_CALLBACKS"


### PR DESCRIPTION
This PR is a work-in-progress toward supporting building Caffeine with LLVM 20 installed by Homebrew.
Issues addressed
- [x] Detect LLVM in `install.sh`
- [ ] Find `ISO_Fortran_binding.h`
- [ ] ...