### PR TITLE
Implement image_index_with_team and this_image_with_{coarray,dim}, partial {image_index,num_images}_with_team_number

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -87,7 +87,7 @@ are accepted, but in some cases, the associated runtime behavior is not fully im
 | `prif_coshape`                                   | **YES** |  |
 | `prif_local_data_pointer`                        | **YES** |  |
 | `prif_image_index`                               | **YES** |  |
-| `prif_image_index_with_team`                     | no |  |
+| `prif_image_index_with_team`                     | **YES** |  |
 | `prif_image_index_with_team_number`              | no |  |
 
 ---

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -88,7 +88,7 @@ are accepted, but in some cases, the associated runtime behavior is not fully im
 | `prif_local_data_pointer`                        | **YES** |  |
 | `prif_image_index`                               | **YES** |  |
 | `prif_image_index_with_team`                     | **YES** |  |
-| `prif_image_index_with_team_number`              | no |  |
+| `prif_image_index_with_team_number`              | *partial* | no support for sibling teams |
 
 ---
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -56,7 +56,7 @@ are accepted, but in some cases, the associated runtime behavior is not fully im
 | `prif_num_images_with_team`         | **YES** |  |
 | `prif_num_images_with_team_number`  | *partial* | no support for sibling teams |
 | `prif_this_image_no_coarray`        | **YES** |  |
-| `prif_this_image_with_coarray`, `prif_this_image_with_dim`  | no |  |
+| `prif_this_image_with_coarray`, `prif_this_image_with_dim`  | **YES** |  |
 | `prif_failed_images`                | **YES** |  |
 | `prif_stopped_images`               | **YES** |  |
 | `prif_image_status`                 | **YES** |  |

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -54,7 +54,7 @@ are accepted, but in some cases, the associated runtime behavior is not fully im
 |-----------|--------|-------|
 | `prif_num_images`                   | **YES** |  |
 | `prif_num_images_with_team`         | **YES** |  |
-| `prif_num_images_with_team_number`  | no |  |
+| `prif_num_images_with_team_number`  | *partial* | no support for sibling teams |
 | `prif_this_image_no_coarray`        | **YES** |  |
 | `prif_this_image_with_coarray`, `prif_this_image_with_dim`  | no |  |
 | `prif_failed_images`                | **YES** |  |

--- a/src/caffeine/coarray_queries_s.F90
+++ b/src/caffeine/coarray_queries_s.F90
@@ -93,9 +93,13 @@ contains
   end procedure
 
   module procedure prif_image_index_with_team_number
-    call_assert(coarray_handle_check(coarray_handle))
-
-    call unimplemented("prif_image_index_with_team_number")
+    if (team_number == -1) then
+      call image_index_helper(coarray_handle, sub, initial_team%num_images, image_index)
+    else if (team_number == current_team%info%team_number) then
+      call image_index_helper(coarray_handle, sub, current_team%info%num_images, image_index)
+    else
+      call unimplemented("prif_image_index_with_team_number: no support for sibling teams")
+    end if 
   end procedure
 
   module procedure prif_local_data_pointer

--- a/src/caffeine/coarray_queries_s.F90
+++ b/src/caffeine/coarray_queries_s.F90
@@ -45,9 +45,15 @@ contains
     end associate
   end procedure
 
-  module procedure prif_image_index
+  subroutine image_index_helper(coarray_handle, sub, num_images, image_index)
+    implicit none
+    type(prif_coarray_handle), intent(in) :: coarray_handle
+    integer(c_int64_t), intent(in) :: sub(:)
+    integer(c_int), intent(in) :: num_images
+    integer(c_int), intent(out) :: image_index
+
     integer :: dim, i
-    integer(c_int) :: prior_size, num_img
+    integer(c_int) :: prior_size
     logical :: invalid_cosubscripts
 
     call_assert(coarray_handle_check(coarray_handle))
@@ -74,16 +80,17 @@ contains
        end do
     end if
 
-    call prif_num_images(num_images=num_img)
-    if (invalid_cosubscripts .or. image_index .gt. num_img) then
+    if (invalid_cosubscripts .or. image_index .gt. num_images) then
        image_index = 0
     end if
+  end subroutine
+
+  module procedure prif_image_index
+    call image_index_helper(coarray_handle, sub, current_team%info%num_images, image_index)
   end procedure
 
   module procedure prif_image_index_with_team
-    call_assert(coarray_handle_check(coarray_handle))
-
-    call unimplemented("prif_image_index_with_team")
+    call image_index_helper(coarray_handle, sub, team%info%num_images, image_index)
   end procedure
 
   module procedure prif_image_index_with_team_number

--- a/src/caffeine/image_queries_s.F90
+++ b/src/caffeine/image_queries_s.F90
@@ -19,7 +19,13 @@ contains
   end procedure
 
   module procedure prif_num_images_with_team_number
-    call unimplemented("prif_num_images_with_team_number")
+    if (team_number == -1) then
+      num_images = initial_team%num_images 
+    else if (team_number == current_team%info%team_number) then
+      num_images = current_team%info%num_images
+    else
+      call unimplemented("prif_num_images_with_team_number: no support for sibling teams")
+    end if
   end procedure
 
   module procedure prif_this_image_no_coarray

--- a/src/caffeine/image_queries_s.F90
+++ b/src/caffeine/image_queries_s.F90
@@ -37,15 +37,56 @@ contains
   end procedure
 
   module procedure prif_this_image_with_coarray
+    integer(c_int) :: offset, doff, dsz
+    integer :: dim
+
     call_assert(coarray_handle_check(coarray_handle))
 
-    call unimplemented("prif_this_image_with_coarray")
+    if (present(team)) then
+      offset = team%info%this_image - 1
+    else
+      offset = current_team%info%this_image - 1
+    endif
+
+    associate (info => coarray_handle%info)
+      call_assert(size(cosubscripts) == info%corank)
+      do dim = 1, info%corank-1
+        dsz = INT(info%ucobounds(dim) - info%lcobounds(dim) + 1, c_int)
+        doff = mod(offset, dsz)
+        cosubscripts(dim) = doff + info%lcobounds(dim)
+        call_assert(cosubscripts(dim) <= info%ucobounds(dim))
+        offset = offset / dsz
+      end do
+      cosubscripts(info%corank) = offset + info%lcobounds(info%corank)
+      call_assert(cosubscripts(info%corank) <= info%ucobounds(info%corank))
+    end associate
+
+#   if ASSERTIONS
+      block ! sanity check
+        integer(c_int) :: image_index
+        if (present(team)) then
+          call prif_image_index_with_team(coarray_handle, cosubscripts, team, image_index)
+          call_assert(image_index == team%info%this_image)
+        else
+          call prif_image_index(coarray_handle, cosubscripts, image_index)
+          call_assert(image_index == current_team%info%this_image)
+        end if
+      end block
+#   endif
   end procedure
 
   module procedure prif_this_image_with_dim
     call_assert(coarray_handle_check(coarray_handle))
 
-    call unimplemented("prif_this_image_with_dim")
+    block
+      integer(c_int64_t) :: cosubscripts(coarray_handle%info%corank)
+
+      call_assert(dim >= 1 .and. dim <= coarray_handle%info%corank)
+
+      call prif_this_image_with_coarray(coarray_handle, team, cosubscripts)
+
+      cosubscript = cosubscripts(dim)
+    end block
   end procedure
 
   module procedure prif_failed_images

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -499,7 +499,7 @@ module prif
       implicit none
       type(prif_coarray_handle), intent(in) :: coarray_handle
       integer(c_int64_t), intent(in) :: sub(:)
-      integer(c_int), intent(in) :: team_number
+      integer(c_int64_t), intent(in) :: team_number
       integer(c_int), intent(out) :: image_index
     end subroutine
 

--- a/test/prif_image_index_test.F90
+++ b/test/prif_image_index_test.F90
@@ -5,7 +5,8 @@ module caf_image_index_test
                     prif_team_type, prif_get_team, &
                     prif_this_image_no_coarray, &
                     prif_form_team, prif_change_team, prif_end_team, &
-                    prif_image_index_with_team, prif_num_images_with_team
+                    prif_image_index_with_team, prif_image_index_with_team_number, &
+                    prif_num_images_with_team
     use veggies, only: result_t, test_item_t, assert_equals, describe, it, succeed
 
     implicit none
@@ -165,9 +166,21 @@ contains
           result_ = result_ .and. &
             assert_equals(1_c_int, answer)
 
+          call prif_image_index_with_team_number(coarray_handle, &
+                              [0_c_int64_t, 2_c_int64_t], &
+                              team_number=-1_c_int64_t, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(1_c_int, answer)
+
           call prif_image_index_with_team(coarray_handle, &
                               [0_c_int64_t, 2_c_int64_t], &
                               team=child_team, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(1_c_int, answer)
+
+          call prif_image_index_with_team_number(coarray_handle, &
+                              [0_c_int64_t, 2_c_int64_t], &
+                              team_number=which_team, image_index=answer)
           result_ = result_ .and. &
             assert_equals(1_c_int, answer)
 
@@ -183,9 +196,21 @@ contains
           result_ = result_ .and. &
             assert_equals(merge(3_c_int,0_c_int,ni >= 3), answer)
 
+          call prif_image_index_with_team_number(coarray_handle, &
+                              [0_c_int64_t, 3_c_int64_t], &
+                              team_number=-1_c_int64_t, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(merge(3_c_int,0_c_int,ni >= 3), answer)
+
           call prif_image_index_with_team(coarray_handle, &
                               [0_c_int64_t, 3_c_int64_t], &
                               team=child_team, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(merge(3_c_int,0_c_int,cni >= 3), answer)
+
+          call prif_image_index_with_team_number(coarray_handle, &
+                              [0_c_int64_t, 3_c_int64_t], &
+                              team_number=which_team, image_index=answer)
           result_ = result_ .and. &
             assert_equals(merge(3_c_int,0_c_int,cni >= 3), answer)
 

--- a/test/prif_image_index_test.F90
+++ b/test/prif_image_index_test.F90
@@ -1,7 +1,12 @@
 module caf_image_index_test
     use iso_c_binding, only: c_int, c_ptr, c_size_t, c_null_funptr, c_int64_t
-    use prif, only: prif_coarray_handle, prif_allocate_coarray, prif_deallocate_coarray, prif_image_index, prif_num_images
-    use veggies, only: result_t, test_item_t, assert_equals, describe, it
+    use prif, only: prif_coarray_handle, prif_allocate_coarray, prif_deallocate_coarray, &
+                    prif_image_index, prif_num_images, &
+                    prif_team_type, prif_get_team, &
+                    prif_this_image_no_coarray, &
+                    prif_form_team, prif_change_team, prif_end_team, &
+                    prif_image_index_with_team, prif_num_images_with_team
+    use veggies, only: result_t, test_item_t, assert_equals, describe, it, succeed
 
     implicit none
     private
@@ -15,7 +20,9 @@ contains
           [ it("returns 1 for the simplest case", check_simple_case) &
           , it("returns 1 when given the lower bounds", check_lower_bounds) &
           , it("returns 0 with invalid subscripts", check_invalid_subscripts) &
-          , it("returns the expected answer for a more complicated case", check_complicated) &
+          , it("returns the expected answer for a more complicated case w/corank=2", check_complicated_2d) &
+          , it("returns the expected answer for a more complicated case w/corank=3", check_complicated_3d) &
+          , it("returns the expected answer with a child team and corank=2", check_complicated_2d_team) &
           ])
     end function
 
@@ -79,7 +86,7 @@ contains
         call prif_deallocate_coarray([coarray_handle])
     end function
 
-    function check_complicated() result(result_)
+    function check_complicated_2d() result(result_)
         type(result_t) :: result_
 
         type(prif_coarray_handle) :: coarray_handle
@@ -98,4 +105,100 @@ contains
         result_ = assert_equals(merge(3_c_int,0_c_int,ni >= 3), answer)
         call prif_deallocate_coarray([coarray_handle])
     end function
+
+    function check_complicated_3d() result(result_)
+        type(result_t) :: result_
+
+        type(prif_coarray_handle) :: coarray_handle
+        type(c_ptr) :: allocated_memory
+        integer(c_int) :: answer, ni
+        type(prif_team_type) :: initial_team
+        call prif_get_team(team=initial_team)
+        call prif_num_images_with_team(team=initial_team, num_images=ni)
+
+        call prif_allocate_coarray( &
+                lcobounds = [1_c_int64_t, 0_c_int64_t, 0_c_int64_t], &
+                ucobounds = [2_c_int64_t, 1_c_int64_t, ni+0_c_int64_t], &
+                size_in_bytes = 1_c_size_t, &
+                final_func = c_null_funptr, &
+                coarray_handle = coarray_handle, &
+                allocated_memory = allocated_memory)
+        call prif_image_index_with_team(coarray_handle, &
+                           [2_c_int64_t, 1_c_int64_t, 1_c_int64_t], &
+                           team=initial_team, image_index=answer)
+        result_ = assert_equals(merge(8_c_int,0_c_int,ni >= 8), answer)
+        call prif_deallocate_coarray([coarray_handle])
+    end function
+
+    function check_complicated_2d_team() result(result_)
+        type(result_t) :: result_
+
+        type(prif_coarray_handle) :: coarray_handle
+        type(c_ptr) :: allocated_memory
+        integer(c_int) :: answer, ni, cni, me
+        integer(c_int64_t) :: which_team
+        type(prif_team_type) :: initial_team, child_team
+
+        result_ = succeed("")
+
+        call prif_get_team(team=initial_team)
+        call prif_num_images_with_team(team=initial_team, num_images=ni)
+        call prif_this_image_no_coarray(this_image=me)
+
+        call prif_allocate_coarray( &
+                lcobounds = [0_c_int64_t, 2_c_int64_t], &
+                ucobounds = [1_c_int64_t, ni+3_c_int64_t], &
+                size_in_bytes = 1_c_size_t, &
+                final_func = c_null_funptr, &
+                coarray_handle = coarray_handle, &
+                allocated_memory = allocated_memory)
+
+        which_team = merge(1_c_int64_t, 2_c_int64_t, mod(me, 2) == 0)
+        call prif_form_team(team_number = which_team, team = child_team)
+        call prif_change_team(child_team)
+
+          call prif_num_images_with_team(team=child_team, num_images=cni)
+
+          call prif_image_index_with_team(coarray_handle, &
+                              [0_c_int64_t, 2_c_int64_t], &
+                              team=initial_team, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(1_c_int, answer)
+
+          call prif_image_index_with_team(coarray_handle, &
+                              [0_c_int64_t, 2_c_int64_t], &
+                              team=child_team, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(1_c_int, answer)
+
+          call prif_image_index(coarray_handle, &
+                              [0_c_int64_t, 2_c_int64_t], &
+                              image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(1_c_int, answer)
+
+          call prif_image_index_with_team(coarray_handle, &
+                              [0_c_int64_t, 3_c_int64_t], &
+                              team=initial_team, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(merge(3_c_int,0_c_int,ni >= 3), answer)
+
+          call prif_image_index_with_team(coarray_handle, &
+                              [0_c_int64_t, 3_c_int64_t], &
+                              team=child_team, image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(merge(3_c_int,0_c_int,cni >= 3), answer)
+
+          call prif_image_index(coarray_handle, &
+                              [0_c_int64_t, 3_c_int64_t], &
+                              image_index=answer)
+          result_ = result_ .and. &
+            assert_equals(merge(3_c_int,0_c_int,cni >= 3), answer)
+
+        call prif_end_team()
+        call prif_deallocate_coarray([coarray_handle])
+    end function
+
+
+
 end module

--- a/test/prif_teams_test.F90
+++ b/test/prif_teams_test.F90
@@ -59,6 +59,11 @@ contains
           assert_equals(x, initial_num_imgs, "prif_num_images works with initial team")
 
         x = 0 ! clear outputs
+        call prif_num_images_with_team_number(team_number=-1_c_int64_t, num_images=x)
+        result_ = result_ .and. &
+          assert_equals(x, initial_num_imgs, "prif_num_images_with_team_number works with initial team")
+
+        x = 0 ! clear outputs
         call prif_this_image_no_coarray(team=initial_team, this_image=x)
         result_ = result_ .and. &
           assert_equals(x, me, "prif_this_image_no_coarray works with initial team")
@@ -100,6 +105,11 @@ contains
             call prif_num_images_with_team(team=team, num_images=x)
             result_ = result_ .and. &
               assert_equals(x, num_imgs, "prif_num_images works with team")
+
+            x = 0 ! clear outputs
+            call prif_num_images_with_team_number(team_number=which_team, num_images=x)
+            result_ = result_ .and. &
+              assert_equals(x, num_imgs, "prif_num_images_with_team_number works with current team")
 
             call prif_this_image_no_coarray(this_image=me_child)
             result_ = result_ .and. &
@@ -148,6 +158,11 @@ contains
             call prif_num_images_with_team(team=initial_team, num_images=x)
             result_ = result_ .and. &
               assert_equals(x, initial_num_imgs, "prif_num_images works with initial team")
+
+            x = 0 ! clear outputs
+            call prif_num_images_with_team_number(team_number=-1_c_int64_t, num_images=x)
+            result_ = result_ .and. &
+              assert_equals(x, initial_num_imgs, "prif_num_images_with_team_number works with initial team")
 
             x = 0 ! clear outputs
             call prif_this_image_no_coarray(team=initial_team, this_image=x)


### PR DESCRIPTION
Adds a complete implementation of `prif_image_index_with_team`, by factoring the existing `prif_image_index` implementation.

Adds a complete implementation of `prif_this_image_with_{coarray,dim}`

Adds partial implementations for `prif_{image_index,num_images}_with_team_number` (for the cases that can be implemented efficiently/scalably).

Fixes #214
Fixes #215
Fixes #227