### PR TITLE
Support distributed-memory (network) configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,19 +34,19 @@ jobs:
             version: 20
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
             container: phhargrove/llvm-flang:20.1.0-1
-            SUBJOB_PREFIX: GASNET_PSHM_NODES=2
+            SUBJOB_PREFIX: CAF_IMAGES=2
           - os: ubuntu-24.04
             compiler: flang
             version: 19
             FFLAGS: -mmlir -allow-assumed-rank
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
             container: phhargrove/llvm-flang:19.1.1-1
-            SUBJOB_PREFIX: GASNET_PSHM_NODES=2
+            SUBJOB_PREFIX: CAF_IMAGES=2
 #          - os: ubuntu-24.04
 #            compiler: flang
 #            version: new
 #            container: gmao/llvm-flang:latest
-#            SUBJOB_PREFIX: GASNET_PSHM_NODES=2
+#            SUBJOB_PREFIX: CAF_IMAGES=2
 
     container:
       image: ${{ matrix.container }}
@@ -56,7 +56,7 @@ jobs:
       FFLAGS: ${{ matrix.FFLAGS }}
       PREFIX: install
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
-      GASNET_PSHM_NODES: 8
+      CAF_IMAGES: 8
       SUBJOB_PREFIX: ${{ matrix.SUBJOB_PREFIX }}
 
     steps:
@@ -141,7 +141,7 @@ jobs:
 
     - name: Run examples
       run: |
-        echo GASNET_PSHM_NODES=${GASNET_PSHM_NODES}
+        echo CAF_IMAGES=${CAF_IMAGES}
         set -x
         ./build/run-fpm.sh run --verbose --example hello
         ./build/run-fpm.sh run --verbose --example stop_with_no_code
@@ -151,10 +151,10 @@ jobs:
     - name: Run unit tests
       run: |
         echo SUBJOB_PREFIX=${SUBJOB_PREFIX}
-        while (( GASNET_PSHM_NODES > 0 )); do \
-          echo GASNET_PSHM_NODES=${GASNET_PSHM_NODES} ; \
+        while (( CAF_IMAGES > 0 )); do \
+          echo CAF_IMAGES=${CAF_IMAGES} ; \
           ( set -x ; ./build/run-fpm.sh test --verbose -- -d ) ; \
           sleep 1 ; \
-          GASNET_PSHM_NODES=$(( GASNET_PSHM_NODES / 2 )) ; \
+          CAF_IMAGES=$(( CAF_IMAGES / 2 )) ; \
         done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ defaults:
 
 jobs:
   build:
-    name: ${{ matrix.compiler }}-${{ matrix.version }} (${{ matrix.os }})
+    name: ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.network }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -16,37 +16,62 @@ jobs:
         os: [macos-13, macos-14, macos-15, ubuntu-24.04]
         compiler: [ gfortran ]
         version: [ 13, 14 ]
+        network: [ smp ]
         exclude:
           - os: macos-15 # gcc-13 broken on macos-15
+            compiler: gfortran
             version: 13
+            network: smp
         include:
+        # --- flang coverage ---
           - os: macos-13
             compiler: flang
             version: 20
+            network: smp
           - os: macos-14
             compiler: flang
             version: 20
+            network: smp
           - os: macos-15
             compiler: flang
             version: 20
+            network: smp
           - os: ubuntu-24.04
             compiler: flang
             version: 20
+            network: smp
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
             container: phhargrove/llvm-flang:20.1.0-1
-            SUBJOB_PREFIX: CAF_IMAGES=2
           - os: ubuntu-24.04
             compiler: flang
             version: 19
+            network: smp
             FFLAGS: -mmlir -allow-assumed-rank
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
             container: phhargrove/llvm-flang:19.1.1-1
-            SUBJOB_PREFIX: CAF_IMAGES=2
 #          - os: ubuntu-24.04
 #            compiler: flang
 #            version: new
+#            network: smp
 #            container: gmao/llvm-flang:latest
-#            SUBJOB_PREFIX: CAF_IMAGES=2
+        # --- udp coverage for selected configs ---
+          - os: macos-15
+            compiler: gfortran
+            version: 14
+            network: udp
+          - os: ubuntu-24.04
+            compiler: gfortran
+            version: 14
+            network: udp
+          - os: macos-15
+            compiler: flang
+            version: 20
+            network: udp
+          - os: ubuntu-24.04
+            compiler: flang
+            version: 20
+            network: udp
+            container: phhargrove/llvm-flang:20.1.0-1
 
     container:
       image: ${{ matrix.container }}
@@ -56,8 +81,9 @@ jobs:
       FFLAGS: ${{ matrix.FFLAGS }}
       PREFIX: install
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
+      GASNET_SPAWN_VERBOSE: 1
+      GASNET_SPAWNFN: L
       CAF_IMAGES: 8
-      SUBJOB_PREFIX: ${{ matrix.SUBJOB_PREFIX }}
 
     steps:
     - name: Set gfortran variables
@@ -75,6 +101,18 @@ jobs:
         echo "FC=flang-new" >> "$GITHUB_ENV" 
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
+
+    - name: Set Caffeine variables
+      run: |
+        set -x
+        # docker instances cannot handle high levels of subjob parallelism
+        if test -n "${{ matrix.container }}"; then \
+          echo "SUBJOB_PREFIX=CAF_IMAGES=2" >> "$GITHUB_ENV" ; \
+        fi
+        # disable shared-memory bypass with network=udp to simulate multi-node runs
+        if test "${{ matrix.network }}" = "udp"; then \
+          echo "GASNET_SUPERNODE_MAXSIZE=1" >> "$GITHUB_ENV" ; \
+        fi
 
     - name: Checkout code
       uses: actions/checkout@v1
@@ -137,7 +175,7 @@ jobs:
         for var in FC CC CXX FFLAGS CPPFLAGS CFLAGS LDFLAGS LIBS GASNET_CONFIGURE_ARGS ; do \
             eval echo "$var=\$$var"; done
         set -x
-        ./install.sh --prefix=${PREFIX} --verbose
+        ./install.sh --prefix=${PREFIX} --network=${{ matrix.network }} --verbose
 
     - name: Run examples
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,9 +154,10 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') && matrix.os != 'macos-13' }} 
       run: |
         set -x
-        curl --retry 5 -LOsS https://github.com/fortran-lang/fpm/releases/download/v0.11.0/fpm-0.11.0.F90
+        export FPM_VERSION=0.12.0
+        curl --retry 5 -LOsS https://github.com/fortran-lang/fpm/releases/download/v$FPM_VERSION/fpm-$FPM_VERSION.F90
         mkdir fpm-temp
-        gfortran-14 -o fpm-temp/fpm fpm-0.11.0.F90
+        gfortran-14 -o fpm-temp/fpm fpm-$FPM_VERSION.F90
         echo "PATH=${PWD}/fpm-temp:${PATH}" >> "$GITHUB_ENV"
 
     - name: Version info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ If you encounter problems or limitations when installing or using Caffeine, plea
  2. Email the Caffeine [mailing list](mailto:fortran@lbl.gov) for advice.
  3. If steps 1 or 2 do not resolve the problem, please file a [new issue] including
     - [ ] The Fortran compiler and compiler version used with Caffeine,
-    - [ ] The complete output of the build command,
+    - [ ] The complete output of the install and build commands run with `--verbose` argument,
     - [ ] The Caffeine version number or commit hash,
     - [ ] Any conditions required to reproduce the problem such as
       - [ ] The output of `uname -a` showing the operating system (OS), OS version, and processor architecture,
-      - [ ] The number of images executed (e.g., the output of `echo $GASNET_PSHM_NODES`),
+      - [ ] The number of images executed (e.g., the output of `echo $CAF_IMAGES`),
       - [ ] The command used to run your program (e.g., `./build/run-fpm.sh run`), and
       - [ ] A minimal reproducer: if possible, fewer than 50 lines demonstrating an issue.
 

--- a/README.md
+++ b/README.md
@@ -88,13 +88,24 @@ Caffeine leverages the following non-parallel features of Fortran to simplify th
 
 Download, build, and run an example
 -----------------------------------
+Here is an outline of the basic commands used to build Caffeine and run an example:
+
 ```
 git clone https://github.com/BerkeleyLab/caffeine.git
 cd caffeine
-./install.sh
-export GASNET_PSHM_NODES=8
-FC=<Fortran-compiler-path> CC=<C-compiler-path> CXX=<C++-compiler-path> ./build/run-fpm.sh run --example hello
+env FC=<Fortran-compiler> CC=<C-compiler> CXX=<C++-compiler> ./install.sh <options>
+env CAF_IMAGES=8 ./build/run-fpm.sh run --example hello
 ```
+
+The provided compilers MUST be "compatible": for the best experience you are
+HIGHLY recommended to specify the language frontends provided by a single version
+of a given compiler suite installation. The C++ compiler is optional for
+single-node deployments (and can be disabled using command-line option `--without-cxx`), 
+but C++ is required for some network backends.
+
+The `install.sh` recognizes a number of command-line options and environment variables to
+customize behavior for your system. See the output of `./install.sh --help` for full documentation.
+
 
 Example Usage
 -------------
@@ -114,6 +125,31 @@ Run tests
 ```
 ./build/run-fpm.sh test
 ```
+
+Recognized Environment Variables
+--------------------------------
+
+The following environment variables control the execution of the `fpm`-driven Caffeine unit test suite:
+
+* `CAF_IMAGES`: integer number of images to run
+* `SUBJOB_PREFIX`: command prefix to use for recursive `fpm` invocations in the test suite. 
+   Set `SUBJOB_PREFIX=skip` to disable such invocations (recommended for distributed-memory systems).
+
+The following environment variables control the behavior of the Caffeine library:
+
+* `CAF_HEAP_SIZE=128MB`: set the size of the shared-memory heap used for coarray storage, defaults to 128 MiB
+* `CAF_COMP_FRAC=0.10`: set the fraction of the shared-memory heap reserved for non-symmetric allocation, defaults to 10%
+
+Caffeine is built atop the [GASNet-EX] exascale networking middleware, which has its own
+set of environment variable knobs to control network-level behavior. 
+Here are *a few* of the most useful GASNet knobs:
+
+* `GASNET_VERBOSEENV=1`: enable console output of all the envvar settings affecting GASNet operation
+* `GASNET_SPAWN_VERBOSE=1`: enable verbose console output of parallel job-spawning steps
+* `GASNET_BACKTRACE=1`: enable automatic backtrace upon fatal errors
+* `GASNET_SSH_SERVERS="host1 host2"`: space-deliminted list of hostnames for distributed-memory job launch using the ssh-spawner
+
+See [GASNet documentation](https://gasnet.lbl.gov/dist-ex/README) for full details on all settings.
 
 Implementation Status
 --------------------

--- a/src/caffeine/unit_test_parameters_m.F90
+++ b/src/caffeine/unit_test_parameters_m.F90
@@ -38,7 +38,7 @@ contains
         
     call prif_sync_all()
     call prif_this_image_no_coarray(this_image=me)
-    result_ = (me == 1)
+    result_ = (me == 1) .and. (subjob_prefix /= "skip")
   end function 
 
 

--- a/test/a00_caffeinate_test.F90
+++ b/test/a00_caffeinate_test.F90
@@ -4,7 +4,7 @@ module a00_caffeinate_test
 
     implicit none
     private
-    public :: test_caffeinate
+    public :: test_caffeinate, check_caffeination
 
 contains
 
@@ -20,13 +20,25 @@ contains
     end function
 
     function check_caffeination() result(result_)
-        type(result_t) :: result_
+      ! this test needs to run very early at startup, so we memoize the result
+      type(result_t) :: result_
+      type(result_t), save :: myresult
+      logical, save :: once = .false.
 
+      if (once) then
+        result_ = myresult
+        return
+      endif 
+      once = .true.
+
+      block
         integer, parameter :: successful_initiation = 0
         integer :: init_exit_code
 
         call prif_init(init_exit_code)
-        result_ = assert_that(init_exit_code == successful_initiation)
+        myresult = assert_that(init_exit_code == successful_initiation)
+        result_ = myresult
+      end block
     end function
 
     function check_subsequent_prif_init_call() result(result_)

--- a/test/main.F90
+++ b/test/main.F90
@@ -17,6 +17,7 @@ program main
 contains
     function run() result(passed)
         use a00_caffeinate_test, only: &
+                check_caffeination, &
                 a00_caffeinate_caffeinate => &
                     test_caffeinate
         use caf_allocate_test, only: &
@@ -63,7 +64,7 @@ contains
                     test_prif_this_image_no_coarray
         use caf_stop_test, only: test_prif_stop
         use caf_error_stop_test, only: test_prif_error_stop
-        use veggies, only: test_item_t, test_that, run_tests
+        use veggies, only: test_item_t, test_that, run_tests, result_t
 
 
 
@@ -71,6 +72,10 @@ contains
 
         type(test_item_t) :: tests
         type(test_item_t), allocatable :: individual_tests(:)
+        type(result_t) :: dummy
+
+        ! ensure an early call to prif_init
+        dummy = check_caffeination()
 
         allocate(individual_tests(0))
 


### PR DESCRIPTION
This PR adds the support (mostly scripting) necessary to build Caffeine against distributed-memory GASNet conduits.

The UI changes are:

* `install.sh` now takes an optional `--network=<net>` argument, defaulting to `smp` (preserving current behavior)
* Job scale of `fpm`-driven tests is now controlled using new envvar `CAF_IMAGES`

The updates pass manual Caffeine testing on all of the following backends, with both gfortran-14 and flang-20:

* smp-conduit (several systems)
* udp-conduit (several multi-node systems)
* ibv-conduit (cgpu 2-node InfiniBand)
* ucx-conduit (cgpu 2-node InfiniBand)
* ofi-conduit (Perlmutter Slingshot-11)

Also some related work:

* Fix our test code to ensure `prif_init` (and hence `gex_Client_Init`) runs before any Veggies code, as recommended for all GASNet programs
* Upgrade CI to include some automated udp-conduit runs, simulating multi-node operation
* Remove all use of `GASNET_PSHM_NODES` in favor of `CAF_IMAGES`. The (now undocumented) `GASNET_PSHM_NODES` variable is used as a fallback default for smp-conduit runs when `CAF_IMAGES` is unset.
* Add envvar setting `SUBJOB_PREFIX=skip` as a "kill switch" to disable tests that recursively invoke `fpm`, a practice which is slow and unreliable on clusters, resolving #137
* Update `fpm` in CI to 0.12.0

Fixes #66
Fixes #137
Fixes #221