### PR TITLE
CI: Tell setup-fpm to use the latest fpm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
       if: ${{ !contains(matrix.os, 'macos') || matrix.os == 'macos-13' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        fpm-version: latest
 
     - name: Build FPM
       # no macos-arm64 fpm distro, build from source


### PR DESCRIPTION
This ensures the setup-fpm action in CI uses the latest fpm (currently 0.12.0), instead of the default of 0.11.0