### PR TITLE
[NO REVIEW]: Add LLVM 21 to CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,20 +47,20 @@ jobs:
             version: 21
             network: smp
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
-            container: phhargrove/llvm-flang:21.1.0-4
+            container: phhargrove/llvm-flang:21.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 20
             network: smp
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
-            container: phhargrove/llvm-flang:20.1.0-1
+            container: phhargrove/llvm-flang:20.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 19
             network: smp
             FFLAGS: -mmlir -allow-assumed-rank
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
-            container: phhargrove/llvm-flang:19.1.1-1
+            container: phhargrove/llvm-flang:19.1.1-latest
 #          - os: ubuntu-24.04
 #            compiler: flang
 #            version: new
@@ -83,12 +83,12 @@ jobs:
             compiler: flang
             version: 20
             network: udp
-            container: phhargrove/llvm-flang:20.1.0-1
+            container: phhargrove/llvm-flang:20.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 21
             network: udp
-            container: phhargrove/llvm-flang:21.1.0-4
+            container: phhargrove/llvm-flang:21.1.0-latest
 
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,13 +171,11 @@ jobs:
     - name: Version info
       run: |
         echo == TOOL VERSIONS ==
-        set -x
-        uname -a
-        if test -r /etc/os-release ; then cat /etc/os-release ; fi
-        ${FC} --version
-        ${CC} --version
-        ${CXX} --version
-        fpm --version
+        (set -x ; uname -a )
+        if test -r /etc/os-release ; then (set -x ; cat /etc/os-release ) ; fi
+        for tool in ${FC} ${CC} ${CXX} fpm ; do
+          ( set -x ; w=$(which $tool) ; ls -al $w ; ls -alhL $w ; $tool --version )
+        done
 
     - name: Build Caffeine (install.sh)
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,12 @@ jobs:
             container: snowstep/llvm:noble
           - os: ubuntu-24.04
             compiler: flang
+            version: 21
+            network: smp
+            # https://hub.docker.com/r/phhargrove/llvm-flang/tags
+            container: phhargrove/llvm-flang:21.1.0-4
+          - os: ubuntu-24.04
+            compiler: flang
             version: 20
             network: smp
             # https://hub.docker.com/r/phhargrove/llvm-flang/tags
@@ -78,6 +84,11 @@ jobs:
             version: 20
             network: udp
             container: phhargrove/llvm-flang:20.1.0-1
+          - os: ubuntu-24.04
+            compiler: flang
+            version: 21
+            network: udp
+            container: phhargrove/llvm-flang:21.1.0-4
 
     container:
       image: ${{ matrix.container }}


### PR DESCRIPTION
LLVM 21.1.0 was released today, add it to CI on Linux.

A few related minor tweaks.