### PR TITLE
[NO REVIEW]: CI: Bump macOS to flang-21, matching Homebrew advance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,15 +26,15 @@ jobs:
         # --- flang coverage ---
           - os: macos-13
             compiler: flang
-            version: 20
+            version: 21
             network: smp
           - os: macos-14
             compiler: flang
-            version: 20
+            version: 21
             network: smp
           - os: macos-15
             compiler: flang
-            version: 20
+            version: 21
             network: smp
           - os: ubuntu-24.04
             compiler: flang


### PR DESCRIPTION
The flang Homebrew formula only provides a single version, so we are locked to that version.