### PR TITLE
PRIF 0.6 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ Paper: <https://doi.org/10.25344/S4N017>
 
 ### PRIF Specification:
 
-Dan Bonachea, Katherine Rasmussen, Brad Richardson, Damian Rouson.    
-"[**Parallel Runtime Interface for Fortran (PRIF) Specification, Revision 0.5**](https://github.com/BerkeleyLab/caffeine/wiki/pubs/PRIF_0.5.pdf)",     
-Lawrence Berkeley National Laboratory Technical Report (LBNL-2001636), Dec 2024.    
-<https://doi.org/10.25344/S4CG6G>
+PRIF Committee.    
+"[**Parallel Runtime Interface for Fortran (PRIF) Specification, Revision 0.6**](https://github.com/BerkeleyLab/caffeine/wiki/pubs/PRIF_0.6.pdf)",     
+Lawrence Berkeley National Laboratory Technical Report (LBNL-2001698), Sept 2025.    
+<https://doi.org/10.25344/S4M01X>
 
 Funding
 -------

--- a/docs/README-release.md
+++ b/docs/README-release.md
@@ -17,7 +17,9 @@ Release Procedure for Caffeine
     4. Review top-level [README.md](../README.md) and other user-facing documentation for any
        necessary changes
     5. Update [docs/implementation-status.md](../docs/implementation-status.md) with current status
-    6. Temporarily hardcode version of gasnet installer in [install.sh](../install.sh) as the
+    6. If the PRIF specification revision is changing, search and update all instances of the old revision,
+       including `PRIF_VERSION_{MAJOR,MINOR}` in [prif.F90](../src/prif.F90)
+    7. Temporarily hardcode version of gasnet installer in [install.sh](../install.sh) as the
        last commit in the release. Set GASNET_VERSION flag to the latest gasnet release
 5. Produce the ChangeLog
     1. Create draft release on GitHub

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -71,7 +71,7 @@ are accepted, but in some cases, the associated runtime behavior is not fully im
 | `prif_allocate`            | **YES** |  |
 | `prif_deallocate_coarray`  | *partial* | no `final_func` arg support |
 | `prif_deallocate`          | **YES** |  |
-| `prif_alias_create`        | **YES** | includes `data_pointer_offset` argument expected in PRIF 0.6 |
+| `prif_alias_create`        | **YES** | includes `data_pointer_offset` argument added in PRIF 0.6 |
 | `prif_alias_destroy`       | **YES** |  |
 
 ---
@@ -89,9 +89,9 @@ are accepted, but in some cases, the associated runtime behavior is not fully im
 | `prif_image_index`                               | **YES** |  |
 | `prif_image_index_with_team`                     | **YES** |  |
 | `prif_image_index_with_team_number`              | *partial* | no support for sibling teams |
-| `prif_initial_team_index`                        | **YES** | expected in PRIF 0.6 |
-| `prif_initial_team_index_with_team`              | **YES** | expected in PRIF 0.6 |
-| `prif_initial_team_index_with_team_number`       | *partial* | expected in PRIF 0.6, no support for sibling teams |
+| `prif_initial_team_index`                        | **YES** | |
+| `prif_initial_team_index_with_team`              | **YES** | |
+| `prif_initial_team_index_with_team_number`       | *partial* | no support for sibling teams |
 
 ---
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -2,7 +2,7 @@
 
 Caffeine is an implementation of the Parallel Runtime Interface for Fortran (PRIF). This document
 outlines the implementation status in Caffeine of the features defined in the
-[latest PRIF specification, revision 0.5](https://dx.doi.org/10.25344/S4CG6G). Caffeine contains interfaces for all
+[latest PRIF specification, revision 0.6](https://doi.org/10.25344/S4M01X). Caffeine contains interfaces for all
 of the PRIF procedures (except when stated otherwise below) and the symbols are linkable and callable, but some procedures will fail at runtime with an unimplemented error. For
 more details about the implementation of the various PRIF features, please see the
 following sections:

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -48,7 +48,7 @@ module prif
   public :: prif_atomic_ref_int, prif_atomic_ref_int_indirect, prif_atomic_ref_logical, prif_atomic_ref_logical_indirect
 
   integer(c_int), parameter, public :: PRIF_VERSION_MAJOR = 0
-  integer(c_int), parameter, public :: PRIF_VERSION_MINOR = 5
+  integer(c_int), parameter, public :: PRIF_VERSION_MINOR = 6
 
   integer(c_int), parameter, public :: PRIF_ATOMIC_INT_KIND = c_int64_t
 


### PR DESCRIPTION
Now that PRIF 0.6 technical content is finalized, update references in Caffeine for the pending release.