### PR TITLE
Add CI-driven tests of native multi-image support with flang-latest and Caffeine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             version: latest
             network: smp
             # https://hub.docker.com/r/snowstep/llvm/tags
-            container: snowstep/llvm:noble
+            container: snowstep/llvm:focal
           - os: ubuntu-24.04
             compiler: flang
             version: 21

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
             compiler: flang
             version: latest
             network: smp
+            native_multi_image: 1
+            FFLAGS: -fcoarray -DHAVE_SYNC=0 -DHAVE_COLLECTIVES=0
             # https://hub.docker.com/r/snowstep/llvm/tags
             container: snowstep/llvm:focal
           - os: ubuntu-24.04
@@ -131,6 +133,10 @@ jobs:
         if test "${{ matrix.network }}" = "udp"; then \
           echo "GASNET_SUPERNODE_MAXSIZE=1" >> "$GITHUB_ENV" ; \
         fi
+        if (( ${{ matrix.native_multi_image }} )); then \
+          echo "FFLAGS=$FFLAGS -DHAVE_MULTI_IMAGE" >> "$GITHUB_ENV" ; \
+        fi
+
 
     - name: Checkout code
       uses: actions/checkout@v1
@@ -200,6 +206,11 @@ jobs:
         echo CAF_IMAGES=${CAF_IMAGES}
         set -x
         ./build/run-fpm.sh run --verbose --example hello
+
+    - name: Run native multi-image test
+      if: ${{ matrix.native_multi_image }}
+      run: |
+        set -x ; ./build/run-fpm.sh run --verbose
 
     - name: Run unit tests
       run: |

--- a/app/native-multi-image.F90
+++ b/app/native-multi-image.F90
@@ -1,0 +1,124 @@
+! This multi-image Fortran program just exercises basic calls into each of the
+! native multi-image features from the Fortran level.
+! This test requires a compiler with multi-image features (possibly via Caffeine).
+! This program is NOT designed to evaluate runtime correctness, just to exercise
+! some basic calls to the features.
+
+program native_multi_image
+
+#if HAVE_MULTI_IMAGE
+! feature control:
+#ifndef HAVE_SYNC
+#define HAVE_SYNC 1
+#endif
+#ifndef HAVE_SYNC_ALL
+#define HAVE_SYNC_ALL HAVE_SYNC
+#endif
+#ifndef HAVE_SYNC_MEMORY
+#define HAVE_SYNC_MEMORY HAVE_SYNC
+#endif
+#ifndef HAVE_SYNC_IMAGES
+#define HAVE_SYNC_IMAGES HAVE_SYNC
+#endif
+#ifndef HAVE_COLLECTIVES
+#define HAVE_COLLECTIVES 1
+#endif
+#ifndef HAVE_CO_SUM
+#define HAVE_CO_SUM HAVE_COLLECTIVES
+#endif
+#ifndef HAVE_CO_MIN
+#define HAVE_CO_MIN HAVE_COLLECTIVES
+#endif
+#ifndef HAVE_CO_MAX
+#define HAVE_CO_MAX HAVE_COLLECTIVES
+#endif
+#ifndef HAVE_CO_BROADCAST
+#define HAVE_CO_BROADCAST HAVE_COLLECTIVES
+#endif
+
+  USE, INTRINSIC :: ISO_FORTRAN_ENV
+  integer :: me, ni, peer, tmp
+  character(len=5) :: c
+
+  me = THIS_IMAGE()
+  ni = NUM_IMAGES()
+  peer = MIN(IEOR(me-1,1)+1, ni)
+
+  write(*,'(A,I1,A,I1,A)') "Hello, world! From image ", me, " of ", ni, " images"
+
+# if HAVE_SYNC_ALL
+    call status("Testing SYNC ALL...")
+    call sync_all
+# endif
+
+# if HAVE_SYNC_MEMORY
+    call status("Testing SYNC MEMORY...")
+    SYNC MEMORY
+# endif
+
+# if HAVE_SYNC_IMAGES
+    call status("Testing SYNC IMAGES...")
+    SYNC IMAGES(*)
+    SYNC IMAGES(peer)
+    SYNC IMAGES([peer])
+    if (me /= peer) SYNC IMAGES([me, peer])
+#endif
+
+  tmp = me
+  c = "hello"
+# if HAVE_CO_SUM
+    call status("Testing CO_SUM...")
+    call CO_SUM(tmp)
+    call CO_SUM(tmp,1)
+# endif
+# if HAVE_CO_MIN
+    call status("Testing CO_MIN...")
+    call CO_MIN(tmp)
+    call CO_MIN(tmp,1)
+    call CO_MIN(c)
+    call CO_MIN(c,1)
+# endif
+# if HAVE_CO_MAX
+    call status("Testing CO_MAX...")
+    call CO_MAX(tmp)
+    call CO_MAX(tmp,1)
+    call CO_MAX(c)
+    call CO_MAX(c,1)
+# endif
+# if HAVE_CO_BROADCAST
+    call status("Testing CO_BROADCAST...")
+    call CO_BROADCAST(tmp,1)
+    call CO_BROADCAST(c,1)
+# endif
+
+  call sync_all
+  write(*,'(A,I1,A,I1,A)') "Goodbye from image ", me, " of ", ni, " images"
+
+  ! explicit flush for now until we have multi-image stop support
+  call flush_all
+  call sync_all
+  stop
+
+  contains
+    subroutine sync_all
+#   if HAVE_SYNC_ALL
+      SYNC ALL
+#   endif
+    end subroutine
+    subroutine flush_all
+      flush output_unit
+      flush error_unit
+    end subroutine
+    subroutine status(str)
+      character(len=*) :: str
+      call flush_all
+      call sync_all
+      if (THIS_IMAGE() == 1) write(*,*) str
+      call flush_all
+      call sync_all
+    end subroutine
+
+#else
+  stop "Native multi-image test disabled"
+#endif
+end program

--- a/example/hello.F90
+++ b/example/hello.F90
@@ -5,14 +5,17 @@ program hello_world
     ,prif_this_image_no_coarray &
     ,prif_num_images &
     ,prif_stop &
-    ,prif_error_stop
+    ,prif_error_stop &
+    ,PRIF_STAT_ALREADY_INIT
   implicit none
 
   integer :: init_exit_code, me, num_imgs
   logical(kind=c_bool), parameter :: false = .false._c_bool
 
   call prif_init(init_exit_code)
-  if (init_exit_code /= 0) call prif_error_stop(quiet=false, stop_code_char="program startup failed")
+  if (init_exit_code /= 0 .and. init_exit_code /= PRIF_STAT_ALREADY_INIT) then
+    call prif_error_stop(quiet=false, stop_code_char="program startup failed")
+  end if
 
   call prif_this_image_no_coarray(this_image=me)
   call prif_num_images(num_images=num_imgs)

--- a/example/support-test/exit_case.F90
+++ b/example/support-test/exit_case.F90
@@ -7,7 +7,8 @@ program hello_world
     ,prif_num_images &
     ,prif_stop &
     ,prif_error_stop &
-    ,prif_sync_all
+    ,prif_sync_all &
+    ,PRIF_STAT_ALREADY_INIT
   implicit none
 
   integer :: init_exit_code, me, num_imgs, exitcase = 1
@@ -15,7 +16,9 @@ program hello_world
   character(len=256) :: arg_string
 
   call prif_init(init_exit_code)
-  if (init_exit_code /= 0) call prif_error_stop(quiet=false, stop_code_char="program startup failed")
+  if (init_exit_code /= 0 .and. init_exit_code /= PRIF_STAT_ALREADY_INIT) then
+    call prif_error_stop(quiet=false, stop_code_char="program startup failed")
+  end if
 
   call prif_this_image_no_coarray(this_image=me)
   call prif_num_images(num_images=num_imgs)

--- a/test/a00_caffeinate_test.F90
+++ b/test/a00_caffeinate_test.F90
@@ -32,7 +32,11 @@ contains
       once = .true.
 
       block
+#if HAVE_MULTI_IMAGE
+        integer, parameter :: successful_initiation = PRIF_STAT_ALREADY_INIT
+#else
         integer, parameter :: successful_initiation = 0
+#endif
         integer :: init_exit_code
 
         call prif_init(init_exit_code)


### PR DESCRIPTION
This PR adds a new test that _natively_ uses multi-image Fortran features in app/native-multi-image.F90 (i.e., _without_ direct calls to PRIF). This relies upon and activates compiler support for multi-image features. The test is preprocessor-parameterized by feature support so that we can easily and gradually enable CI for the widening feature set being merged upstream into flang.

CI for flang-latest (only) now includes a "Run native multi-image test" that builds and runs this new test using the flang compiler, passing `-fcoarray` and linking to Caffeine.

Adjust a few existing tests to allow for the possibility that the compiler has automatically called `prif_init` before `main`.