### PR TITLE
[NO REVIEW]: CI: enable end-to-end testing of `CO_{BROADCAST, MAX, MIN, SUM}`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             version: latest
             network: smp
             native_multi_image: 1
-            FFLAGS: -fcoarray -DHAVE_SYNC=0 -DHAVE_COLLECTIVES=0
+            FFLAGS: -fcoarray -DHAVE_SYNC=0
             # https://hub.docker.com/r/snowstep/llvm/tags
             container: snowstep/llvm:bookworm
           - os: ubuntu-24.04


### PR DESCRIPTION
Our automated nightly flang:bookworm container build has now advanced to include the lowering added in [llvm/llvm-project:#154770](https://github.com/llvm/llvm-project/pull/154770).

As such, we can now automate flang-driven end-to-end testing of `CO_{BROADCAST, MAX, MIN, SUM}`, in our `flang-latest` CI job, in addition to the other end-to-end native multi-image features already exercised by that CI job (`THIS_IMAGE, NUM_IMAGES` from [llvm/llvm-project:#154081](https://github.com/llvm/llvm-project/pull/154081)).