### PR TITLE
[NO REVIEW]: CI: enable end-to-end testing of `SYNC {ALL,IMAGES,MEMORY}` using flang-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             version: latest
             network: smp
             native_multi_image: 1
-            FFLAGS: -fcoarray -DHAVE_SYNC=0
+            FFLAGS: -fcoarray
             # https://hub.docker.com/r/snowstep/llvm/tags
             container: snowstep/llvm:bookworm
           - os: ubuntu-24.04


### PR DESCRIPTION
Our automated nightly flang:bookworm container build has now advanced to include the lowering of `SYNC {ALL,IMAGES,MEMORY}` to PRIF, added in https://github.com/llvm/llvm-project/pull/154166.

As such, we can now automate flang-driven end-to-end testing of `SYNC {ALL,IMAGES,MEMORY}`, in our flang-latest CI job, in addition to the other end-to-end native multi-image features already exercised by that CI job (`THIS_IMAGE`, `NUM_IMAGES` from https://github.com/llvm/llvm-project/pull/154081 and `CO_{BROADCAST, MAX, MIN, SUM}` from https://github.com/llvm/llvm-project/pull/154770).

