### PR TITLE
Adding CMake files to build libcaffeine and native-multi-image test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,157 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+project(caffeine LANGUAGES C CXX Fortran)
+include(ExternalProject)
+
+option(USE_FPM "Specifies whether you want to use FPM to build external dependencies." OFF)
+if(NOT DEFINED BUILD_SHARED_LIBS)
+  set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries" FORCE)
+endif()
+
+add_subdirectory(src)
+
+# ---------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------
+if (NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install)
+endif()
+
+target_include_directories(caffeine PUBLIC ${CMAKE_BINARY_DIR}/include)
+target_include_directories(caffeine PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+message(STATUS "CMAKE_Fortran_COMPILER_ID: ${CMAKE_Fortran_COMPILER_ID}")
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+  # We do that because fpm require to use "flang-new" as a fortran compiler because 
+  # "flang" is used for classic-flang.
+  get_filename_component(_DIR "${CMAKE_Fortran_COMPILER}" DIRECTORY)
+  set(CMAKE_Fortran_COMPILER "${_DIR}/flang-new" CACHE FILEPATH "" FORCE)
+endif()
+
+# --------
+# Assert
+# --------
+SET(ASSERT_GIT "https://github.com/berkeleylab/assert.git")
+SET(ASSERT_TAG "3.0.2")
+if (USE_FPM)
+  set(ASSERT_BUILD_COMMAND fpm build --compiler ${CMAKE_Fortran_COMPILER})
+  set(ASSERT_INSTALL_COMMAND 
+        fpm install --prefix=<INSTALL_DIR> --compiler ${CMAKE_Fortran_COMPILER} &&
+        ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR> &&
+        ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/include <INSTALL_DIR>/include
+  ) 
+else()
+  message(STATUS "USE_FM is not used, libassert will be installed manually from source."
+                 "If you want to use Assert's build system, please enable USE_FPM.")
+  set(ASSERT_BUILD_COMMAND ${CMAKE_Fortran_COMPILER} -c <SOURCE_DIR>/src/assert_m.F90 
+        -I<SOURCE_DIR>/include
+        -DASSERT_MULTI_IMAGE=0
+        -fPIC
+  )
+  set(ASSERT_INSTALL_COMMAND 
+        ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR>/lib &&
+        ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/include <INSTALL_DIR>/include &&
+        ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/assert_m.mod <INSTALL_DIR>/include &&
+        ar rcs <INSTALL_DIR>/lib/libassert.a <SOURCE_DIR>/assert_m.o
+  )
+endif()
+ExternalProject_Add(assert_lib 
+  GIT_REPOSITORY ${ASSERT_GIT} 
+  GIT_TAG ${ASSERT_TAG}
+  CONFIGURE_COMMAND ""
+  INSTALL_DIR ${CMAKE_BINARY_DIR}
+  BUILD_COMMAND ${ASSERT_BUILD_COMMAND} 
+  INSTALL_COMMAND ${ASSERT_INSTALL_COMMAND}
+  BUILD_IN_SOURCE 1
+)
+
+add_library(assert_lib_external STATIC IMPORTED)
+set_target_properties(assert_lib_external PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/lib/libassert.a
+    INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${CMAKE_BINARY_DIR}/include>
+)
+add_dependencies(assert_lib_external assert_lib)
+target_link_libraries(caffeine PRIVATE assert_lib_external)
+
+# -----------
+# GASNet-EX
+# -----------
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+if (NOT DEFINED GASNet_THREADING)
+  set(GASNet_THREADING seq)
+endif()
+if (NOT DEFINED GASNet_PREFERRED_CONDUITS)
+  set(GASNet_PREFERRED_CONDUITS smp)
+endif()
+
+find_package(GASNet QUIET)
+if (NOT GASNet_FOUND)
+  set(GASNet_TAG "2025.8.0")
+  set(GASNet_MD5 "7f61c16c6d06e9789157b3b6804e1927")
+  message(STATUS "Cannot find GASNet-Ex, maybe GASNet_ROOT variable is not set.")
+  message(STATUS "Configuration and building of GASNet-Ex from release ${GASNet_TAG}.")
+  if(BUILD_SHARED_LIBS)
+    if(NOT CMAKE_C_FLAGS MATCHES "-fPIC")
+      set(CMAKE_C_FLAGS "-fPIC ${CMAKE_C_FLAGS}")
+    endif()
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-fPIC")
+      set(CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
+    endif()
+  endif()
+  
+  ExternalProject_Add(gasnet_ex
+      URL https://gasnet.lbl.gov/EX/GASNet-${GASNet_TAG}.tar.gz
+      URL_HASH MD5=${GASNet_MD5}
+      INSTALL_DIR ${CMAKE_BINARY_DIR}/gasnet
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+      DOWNLOAD_NO_EXTRACT FALSE
+      CONFIGURE_COMMAND 
+        <SOURCE_DIR>/configure ac_cv_cxx_exceptions=yes --prefix=<INSTALL_DIR> 
+                               --enable-static --enable-seq
+                               --with-cflags=${CMAKE_C_FLAGS}
+                               --with-cppflags=${CMAKE_CXX_FLAGS}
+                               --with-cc=${CMAKE_C_COMPILER}
+                               --with-cxx=${CMAKE_CXX_COMPILER}
+      BUILD_COMMAND make -j
+      INSTALL_COMMAND make install
+      BUILD_IN_SOURCE 1
+  )
+  set(GASNET_INSTALL ${CMAKE_BINARY_DIR}/gasnet)
+  add_library(gasnet_lib STATIC IMPORTED)
+  set_target_properties(gasnet_lib PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "GASNET_CONDUIT_SMP;GASNET_SEQ"
+      IMPORTED_LOCATION ${GASNET_INSTALL}/lib/libgasnet-smp-seq.a
+      INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${GASNET_INSTALL}/include>
+  )
+  add_dependencies(gasnet_lib gasnet_ex)
+  target_link_libraries(caffeine PUBLIC gasnet_lib)
+  target_include_directories(caffeine PUBLIC ${GASNET_INSTALL}/include)
+  target_include_directories(caffeine PUBLIC ${GASNET_INSTALL}/include/smp-conduit)
+else()
+  target_link_libraries(caffeine PUBLIC GASNet::GASNet)
+endif()
+
+# ---------------------------------------------------------
+# Installation 
+# ---------------------------------------------------------
+install(TARGETS caffeine
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
+
+# ---------------------------------------------------------
+# Test using App 
+# ---------------------------------------------------------
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+  # If you want to view the test logs, please run : make test ARGS="--verbose"
+  enable_testing()
+  add_executable(test_native_multi_image app/native-multi-image.F90)
+  
+  target_compile_options(test_native_multi_image PRIVATE "-fcoarray" "-cpp" "-DHAVE_MULTI_IMAGE")
+  target_link_libraries(test_native_multi_image PRIVATE caffeine)
+  
+  add_test(NAME TestNativeMultiImage COMMAND test_native_multi_image)
+else()
+  message(STATUS "${CMAKE_Fortran_COMPILER_ID} doesn't support lowering to PRIF, not test can't be built.")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (USE_FPM)
         ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/include <INSTALL_DIR>/include
   ) 
 else()
-  message(STATUS "USE_FM is not used, libassert will be installed manually from source."
+  message(STATUS "Since USE_FPM is not enabled, libassert will be installed manually from source."
                  "If you want to use Assert's build system, please enable USE_FPM.")
   set(ASSERT_BUILD_COMMAND ${CMAKE_Fortran_COMPILER} -c <SOURCE_DIR>/src/assert_m.F90 
         -I<SOURCE_DIR>/include
@@ -153,5 +153,5 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
   
   add_test(NAME TestNativeMultiImage COMMAND test_native_multi_image)
 else()
-  message(STATUS "${CMAKE_Fortran_COMPILER_ID} doesn't support lowering to PRIF, not test can't be built.")
+  message(STATUS "${CMAKE_Fortran_COMPILER_ID} doesn't support lowering to PRIF, test can't be built.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,13 +77,16 @@ target_link_libraries(caffeine PRIVATE assert_lib_external)
 # GASNet-EX
 # -----------
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(GASNET_CONFIGURE_ARGS "" CACHE STRING "Arguments to prefix to GASNet-EX configure command (if used).")
 if (NOT DEFINED GASNet_THREADING)
   set(GASNet_THREADING seq)
 endif()
-if (NOT DEFINED GASNet_PREFERRED_CONDUITS)
-  set(GASNet_PREFERRED_CONDUITS smp)
-endif()
 
+# The default conduit is smp
+# TODO: check against an allow list, and ensure lower-case
+set(GASNET_CONDUIT "smp" CACHE STRING "Which GASNet-EX conduit (network) to use")
+
+set(GASNet_PREFERRED_CONDUITS ${GASNET_CONDUIT})
 find_package(GASNet QUIET)
 if (NOT GASNet_FOUND)
   set(GASNet_TAG "2025.8.0")
@@ -98,6 +101,12 @@ if (NOT GASNet_FOUND)
       set(CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
     endif()
   endif()
+
+  if(DEFINED GASNET_CONFIGURE_ARGS)
+    separate_arguments(GASNET_CONFIGURE_LIST NATIVE_COMMAND "${GASNET_CONFIGURE_ARGS}")
+  else()
+    unset(GASNET_CONFIGURE_LIST)
+  endif()
   
   ExternalProject_Add(gasnet_ex
       URL https://gasnet.lbl.gov/EX/GASNet-${GASNet_TAG}.tar.gz
@@ -106,10 +115,15 @@ if (NOT GASNet_FOUND)
       DOWNLOAD_EXTRACT_TIMESTAMP TRUE
       DOWNLOAD_NO_EXTRACT FALSE
       CONFIGURE_COMMAND 
-        <SOURCE_DIR>/configure ac_cv_cxx_exceptions=yes --prefix=<INSTALL_DIR> 
-                               --enable-static --enable-seq
+        <SOURCE_DIR>/configure ${GASNET_CONFIGURE_LIST}
+                               --prefix=<INSTALL_DIR>
+                               --enable-${GASNET_CONDUIT}
+                               --enable-seq --disable-par --disable-parsync
+                               --disable-segment-everything
+                               --disable-mpi-compat
                                --with-cflags=${CMAKE_C_FLAGS}
-                               --with-cppflags=${CMAKE_CXX_FLAGS}
+                               --with-cxxflags=${CMAKE_CXX_FLAGS}
+                               --with-mpi-cflags=${CMAKE_C_FLAGS}
                                --with-cc=${CMAKE_C_COMPILER}
                                --with-cxx=${CMAKE_CXX_COMPILER}
       BUILD_COMMAND make -j
@@ -117,16 +131,48 @@ if (NOT GASNet_FOUND)
       BUILD_IN_SOURCE 1
   )
   set(GASNET_INSTALL ${CMAKE_BINARY_DIR}/gasnet)
+
+  # Generate "response files" with GASNet's (conduit-specific) link flags.
+  # TODO?: Does this make sense to do for every conduit which was compiled?
+  set(GASNET_LDFLAGS_FILE "${GASNET_CONDUIT}-seq-ldflags.rsp")
+  set(GASNET_LIBS_FILE    "${GASNET_CONDUIT}-seq-libs.rsp")
+  find_program(PKG_CONFIG NAMES pkg-config)
+  if(PKG_CONFIG STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "pkg-config not found")
+  endif()
+  set(GASNET_PKG_CONFIG
+    "env" "PKG_CONFIG_PATH=${GASNET_INSTALL}/lib/pkgconfig"
+    "${PKG_CONFIG}" "gasnet-${GASNET_CONDUIT}-seq"
+  )
+  ExternalProject_Add_Step(
+    gasnet_ex dump-vars
+    DEPENDEES install
+    COMMAND ${GASNET_PKG_CONFIG} --variable=GASNET_LDFLAGS > "${GASNET_INSTALL}/lib/${GASNET_LDFLAGS_FILE}"
+    COMMAND ${GASNET_PKG_CONFIG} --variable=GASNET_LIBS    > "${GASNET_INSTALL}/lib/${GASNET_LIBS_FILE}"
+  )
+
   add_library(gasnet_lib STATIC IMPORTED)
+  string(TOUPPER ${GASNET_CONDUIT} _conduit_uppercase)
   set_target_properties(gasnet_lib PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "GASNET_CONDUIT_SMP;GASNET_SEQ"
-      IMPORTED_LOCATION ${GASNET_INSTALL}/lib/libgasnet-smp-seq.a
-      INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${GASNET_INSTALL}/include>
+    INTERFACE_COMPILE_DEFINITIONS "GASNET_CONDUIT_${_conduit_uppercase};GASNET_SEQ"
+    IMPORTED_LOCATION ${GASNET_INSTALL}/lib/libgasnet-${GASNET_CONDUIT}-seq.a
+    INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:${GASNET_INSTALL}/include>
   )
   add_dependencies(gasnet_lib gasnet_ex)
+
+  target_link_options(caffeine PUBLIC
+     "$<BUILD_INTERFACE:@${GASNET_INSTALL}/lib/${GASNET_LDFLAGS_FILE}>"
+     "$<INSTALL_INTERFACE:@${CMAKE_INSTALL_PREFIX}/gasnet/lib/${GASNET_LDFLAGS_FILE}>"
+  )
   target_link_libraries(caffeine PUBLIC gasnet_lib)
+  target_link_libraries(caffeine PUBLIC
+    "$<BUILD_INTERFACE:-Wl,@${GASNET_INSTALL}/lib/${GASNET_LIBS_FILE}>"
+    "$<INSTALL_INTERFACE:-Wl,@${CMAKE_INSTALL_PREFIX}/gasnet/lib/${GASNET_LIBS_FILE}>"
+  )
   target_include_directories(caffeine PUBLIC ${GASNET_INSTALL}/include)
-  target_include_directories(caffeine PUBLIC ${GASNET_INSTALL}/include/smp-conduit)
+  target_include_directories(caffeine PUBLIC ${GASNET_INSTALL}/include/${GASNET_CONDUIT}-conduit)
+
+  install(DIRECTORY "${GASNET_INSTALL}/" DESTINATION "gasnet")
 else()
   target_link_libraries(caffeine PUBLIC GASNet::GASNet)
 endif()

--- a/cmake/FindGASNet.cmake
+++ b/cmake/FindGASNet.cmake
@@ -1,0 +1,354 @@
+#=============================================================================
+# Copyright 2025 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# This module produces the "GASNet" link target which carries with it all the
+# necessary interface properties.  The following options determine which
+# GASNet backend configuration get's used:
+#
+# GASNet_CONDUIT   - Communication conduit to use
+# GASNet_SYSTEM    - system or machine-specific configuration to use for GASNet
+# GASNet_THREADING - Threading mode to use
+#
+# Valid options for these are dependenent on the specific GASNet installation
+#
+# GASNet_PREFERRED_CONDUITS - A list of conduits in order of preference to be
+#                             used by default if found.  The default order of
+#                             preference is mxm, psm, gemini, aries, pami, ibv,
+#                             shmem, portals4, ofi, mpi, udp, and smp.
+# GASNet_ROOT               - Prefix to use when searching for GASNet.  If
+#                             specified then this search path will be used
+#                             exclusively and all others ignored.
+# ENV{GASNET_ROOT}          - Environment variable used to initialize the
+#                             value of GASNet_ROOT if not already specified
+#
+
+macro(_GASNet_parse_conduit_and_threading_names
+  MAKEFILE CONDUIT_LIST_VAR THREADING_LIST_VAR)
+  get_filename_component(_BASE ${MAKEFILE} NAME_WE)
+  string(REGEX MATCH "^([^\\-]*)-([^\\-]*)$" _BASE "${_BASE}")
+  list(FIND ${CONDUIT_LIST_VAR} "${CMAKE_MATCH_1}" _I)
+  if(_I EQUAL -1)
+    list(APPEND ${CONDUIT_LIST_VAR} "${CMAKE_MATCH_1}")
+  endif()
+  list(FIND ${THREADING_LIST_VAR} "${CMAKE_MATCH_2}" _I)
+  if(_I EQUAL -1)
+    list(APPEND ${THREADING_LIST_VAR} "${CMAKE_MATCH_2}")
+  endif()
+endmacro()
+
+macro(_GASNet_parse_conduit_makefile _GASNet_MAKEFILE _GASNet_THREADING)
+  set(_TEMP_MAKEFILE ${CMAKE_CURRENT_BINARY_DIR}/FindGASNetParseConduitOpts.mak)
+  if("${_GASNet_THREADING}" STREQUAL "parsync")
+    file(WRITE ${_TEMP_MAKEFILE} "include ${_GASNet_MAKEFILE}")
+  else()
+    get_filename_component(MFDIR "${_GASNet_MAKEFILE}" DIRECTORY)
+    file(WRITE ${_TEMP_MAKEFILE} "include ${_GASNet_MAKEFILE}")
+  endif()
+  file(APPEND ${_TEMP_MAKEFILE} "
+gasnet-cc:
+	@echo $(GASNET_CC)
+gasnet-cflags:
+	@echo $(GASNET_CPPFLAGS) $(GASNET_CFLAGS)
+gasnet-cxx:
+	@echo $(GASNET_CXX)
+gasnet-cxxflags:
+	@echo $(GASNET_CXXCPPFLAGS) $(GASNET_CXXFLAGS)
+gasnet-ld:
+	@echo $(GASNET_LD)
+gasnet-ldflags:
+	@echo $(GASNET_LDFLAGS)
+gasnet-libs:
+	@echo $(GASNET_LIBS)
+gasnet-ld-requires-mpi:
+	@echo $(GASNET_LD_REQUIRES_MPI)"
+  )
+  find_program(GASNet_MAKE_PROGRAM NAMES gmake make smake)
+  mark_as_advanced(GASNet_MAKE_PROGRAM)
+  if(NOT GASNet_MAKE_PROGRAM)
+    message(WARNING "Unable to locate compatible make for parsing GASNet makefile options")
+  else()
+    execute_process(
+      COMMAND ${GASNet_MAKE_PROGRAM} -s -f ${_TEMP_MAKEFILE} gasnet-cflags
+      OUTPUT_VARIABLE _GASNet_CFLAGS
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    )
+    execute_process(
+      COMMAND ${GASNet_MAKE_PROGRAM} -s -f ${_TEMP_MAKEFILE} gasnet-cxxflags
+      OUTPUT_VARIABLE _GASNet_CXXFLAGS
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    )
+    execute_process(
+      COMMAND ${GASNet_MAKE_PROGRAM} -s -f ${_TEMP_MAKEFILE} gasnet-ld
+      OUTPUT_VARIABLE _GASNet_LD
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    )
+    # Strip any arguments from _GASNet_LD
+    string(REGEX REPLACE "^([^ ]+).*" "\\1" _GASNet_LD "${_GASNet_LD}")
+    execute_process(
+      COMMAND ${GASNet_MAKE_PROGRAM} -s -f ${_TEMP_MAKEFILE} gasnet-ldflags
+      OUTPUT_VARIABLE _GASNet_LDFLAGS
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    )
+    execute_process(
+      COMMAND ${GASNet_MAKE_PROGRAM} -s -f ${_TEMP_MAKEFILE} gasnet-libs
+      OUTPUT_VARIABLE _GASNet_LIBS
+      ERROR_VARIABLE _GASNet_LIBS_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+      COMMAND ${GASNet_MAKE_PROGRAM} -s -f ${_TEMP_MAKEFILE} gasnet-ld-requires-mpi
+      OUTPUT_VARIABLE _GASNet_LD_REQUIRES_MPI
+      ERROR_VARIABLE _GASNet_LD_REQUIRES_MPI_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    file(REMOVE ${_TEMP_MAKEFILE})
+  endif()
+endmacro()
+
+macro(_GASNet_parse_flags INVAR FLAG OUTVAR)
+  # Ignore the optimization flags
+  string(REGEX REPLACE "-O[0-9]" "" INVAR2 "${${INVAR}}")
+  string(REGEX MATCHALL "(^| +)${FLAG}([^ ]*)" OUTTMP "${INVAR2}")
+  foreach(OPT IN LISTS OUTTMP)
+    string(REGEX REPLACE "(^| +)${FLAG}([^ ]*)" "\\2" OPT "${OPT}")
+    if(NOT (OPT STREQUAL "NDEBUG")) # NDEBUG should not get propogated
+      list(FIND ${OUTVAR} "${OPT}" _I)
+      if(_I EQUAL -1)
+        list(APPEND ${OUTVAR} "${OPT}")
+      endif()
+    endif()
+  endforeach()
+endmacro()
+
+function(_GASNet_create_component_target _GASNet_MAKEFILE COMPONENT_NAME)
+  string(REGEX MATCH "^([^\\-]*)-([^\\-]*)$" COMPONENT_NAME "${COMPONENT_NAME}")
+  _GASNet_parse_conduit_makefile(${_GASNet_MAKEFILE} ${CMAKE_MATCH_2})
+
+  foreach(V _GASNet_CFLAGS _GASNet_CXXFLAGS _GASNet_LDFLAGS _GASNet_LIBS)
+    _GASNet_parse_flags(${V} "-I" IDIRS)
+    _GASNet_parse_flags(${V} "-D" DEFS)
+    _GASNet_parse_flags(${V} "-L" LDIRS)
+    _GASNet_parse_flags(${V} "-l" LIBS)
+  endforeach()
+  if(NOT LIBS)
+    message(WARNING "Unable to find link libraries for gasnet-${COMPONENT_NAME}")
+    return()
+  endif()
+
+  foreach(L IN LISTS LIBS)
+    find_library(GASNet_${L}_LIBRARY ${L} PATHS ${LDIRS} NO_DEFAULT_PATH)
+    if(NOT GASNet_${L}_LIBRARY)
+      find_library(GASNet_${L}_LIBRARY ${L})
+    endif()
+    if(GASNet_${L}_LIBRARY)
+      list(APPEND COMPONENT_DEPS "${GASNet_${L}_LIBRARY}")
+    else()
+      message(WARNING
+        "Unable to locate GASNet ${COMPONENT_NAME} dependency ${L}"
+      )
+    endif()
+    mark_as_advanced(GASNet_${L}_LIBRARY)
+  endforeach()
+  if(_GASNet_LD MATCHES "^(/.*/)?mpi[^/]*" AND NOT (_GASNet_LD STREQUAL CMAKE_C_COMPILER))
+    set(MPI_C_COMPILER ${_GASNet_LD})
+    find_package(MPI REQUIRED COMPONENTS C)
+    list(APPEND COMPONENT_DEPS ${MPI_C_LIBRARIES})
+  elseif(_GASNet_LD_REQUIRES_MPI)
+    find_package(MPI REQUIRED COMPONENTS C)
+    list(APPEND COMPONENT_DEPS ${MPI_C_LIBRARIES})
+  endif()
+  add_library(GASNet::${COMPONENT_NAME} UNKNOWN IMPORTED)
+  set_target_properties(GASNet::${COMPONENT_NAME} PROPERTIES
+    IMPORTED_LOCATION "${GASNet_gasnet-${COMPONENT_NAME}_LIBRARY}"
+  )
+  if(DEFS)
+    set_target_properties(GASNet::${COMPONENT_NAME} PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS "${DEFS}"
+    )
+  endif()
+  if(IDIRS)
+    set_target_properties(GASNet::${COMPONENT_NAME} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${IDIRS}"
+    )
+  endif()
+  if(COMPONENT_DEPS)
+    set_target_properties(GASNet::${COMPONENT_NAME} PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${COMPONENT_DEPS}"
+    )
+  endif()
+endfunction()
+
+# Needed for backwards compatibility with older cmake
+macro(list_filter_include varname re)
+  set(tmp_${varname})
+  foreach(item IN LISTS ${varname})
+    if(item MATCHES "${re}")
+      list(APPEND tmp_${varname} ${item})
+    endif()
+  endforeach()
+  set(${varname} ${tmp_${varname}})
+  unset(tmp_${varname})
+endmacro()
+macro(list_filter_exclude varname re)
+  set(tmp_${varname})
+  foreach(item IN LISTS ${varname})
+    if(NOT (item MATCHES "${re}"))
+      list(APPEND tmp_${varname} ${item})
+    endif()
+  endforeach()
+  set(${varname} ${tmp_${varname}})
+  unset(tmp_${varname})
+endmacro()
+
+# This function takes an input list in the variable LVAR and a preferences list
+# in PVAR, and sorts the list in LVAR by the items in PVAR
+function(_sort_list_by_preference LVAR PVAR)
+  string(REPLACE ";" "|" L_RE "${${LVAR}}")
+  list_filter_include(${PVAR} "${L_RE}")
+  string(REPLACE ";" "|" P_RE "${${PVAR}}")
+  list_filter_exclude(${LVAR} "${P_RE}")
+  set(L)
+  list(APPEND L ${${PVAR}})
+  list(APPEND L ${${LVAR}})
+  set(${LVAR} ${L} PARENT_SCOPE)
+endfunction()
+
+if(NOT GASNet_FOUND AND NOT TARGET GASNet::GASNet)
+  set(GASNet_ROOT "$ENV{GASNET_ROOT}" CACHE STRING "Root directory for GASNet")
+  mark_as_advanced(GASNet_ROOT)
+  if(GASNet_ROOT)
+    set(_GASNet_FIND_INCLUDE_OPTS PATHS ${GASNet_ROOT}/include NO_DEFAULT_PATH)
+  else()
+    set(_GASNet_FIND_INCLUDE_OPTS HINTS ENV MPI_INCLUDE)
+  endif()
+  find_path(GASNet_INCLUDE_DIR gasnet.h ${_GASNet_FIND_INCLUDE_OPTS})
+
+  # Make sure that all GASNet componets are found in the same install
+  if(GASNet_INCLUDE_DIR)
+    # Save the existing prefix options
+    set(_CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
+    set(_CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH})
+
+    # Set new restrictive search paths
+    get_filename_component(CMAKE_PREFIX_PATH "${GASNet_INCLUDE_DIR}" DIRECTORY)
+    unset(CMAKE_LIBRARY_PATH)
+    set(GASNet_ROOT ${CMAKE_PREFIX_PATH} CACHE STRING "Root directory for GASNet")
+
+    # Limit the search to the discovered prefix path
+    set(_GASNet_LIBRARY_FIND_OPTS
+      NO_CMAKE_ENVIRONMENT_PATH
+      NO_SYSTEM_ENVIRONMENT_PATH
+      NO_CMAKE_SYSTEM_PATH
+      NO_CMAKE_FIND_ROOT_PATH
+    )
+
+    # Look for the conduit specific headers
+    set(GASNet_CONDUITS)
+    set(GASNet_THREADING_OPTS)
+    file(GLOB _GASNet_CONDUIT_MAKEFILES ${GASNet_INCLUDE_DIR}/*-conduit/*.mak)
+    foreach(CMF IN LISTS _GASNet_CONDUIT_MAKEFILES)
+      # Extract the component name from the makefile
+      get_filename_component(_COMPONENT ${CMF} NAME_WE)
+
+      # Seperate the filename components
+      _GASNet_parse_conduit_and_threading_names("${CMF}"
+        GASNet_CONDUITS GASNet_THREADING_OPTS
+      )
+
+      # Create the component imported target
+      _GASNet_create_component_target("${CMF}" ${_COMPONENT})
+
+      if(NOT TARGET GASNet::${_COMPONENT})
+        message(WARNING "Unable to create GASNet::${_COMPONENT} target")
+      endif()
+    endforeach()
+
+    # Restore the existing prefix options
+    set(CMAKE_PREFIX_PATH ${_CMAKE_PREFIX_PATH})
+    set(CMAKE_LIBRARY_PATH ${_CMAKE_LIBRARY_PATH})
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(GASNet
+    FOUND_VAR GASNet_FOUND
+    REQUIRED_VARS GASNet_INCLUDE_DIR GASNet_CONDUITS GASNet_THREADING_OPTS
+  )
+  if(GASNet_FOUND)
+    # Reorder preferred conduits to place local preferences first
+    set(GASNet_ALL_PREFERRED_CONDUITS
+      "mxm;psm;gemini;aries;pami;ibv;shmem;portals4;ofi;mpi;udp;smp;ucx")
+    set(GASNet_PREFERRED_CONDUITS "${GASNet_ALL_PREFERRED_CONDUITS}"
+      CACHE STRING "")
+    mark_as_advanced(GASNet_PREFERRED_CONDUITS)
+    foreach(C IN LISTS GASNet_PREFERRED_CONDUITS)
+      list(REMOVE_ITEM GASNet_ALL_PREFERRED_CONDUITS ${C})
+    endforeach()
+    list(APPEND GASNet_PREFERRED_CONDUITS ${GASNet_ALL_PREFERRED_CONDUITS})
+    set(GASNet_PREFERRED_CONDUITS "${GASNet_PREFERRED_CONDUITS}"
+      CACHE STRING "" FORCE)
+
+    # Filter the conduit list to only contain what was found
+    _sort_list_by_preference(GASNet_CONDUITS GASNet_PREFERRED_CONDUITS)
+
+    # Stick them in the cache
+    set(GASNet_CONDUITS ${GASNet_CONDUITS} CACHE INTERNAL "")
+    set(GASNet_THREADING_OPTS ${GASNet_THREADING_OPTS} CACHE INTERNAL "")
+    message(STATUS "Found GASNet Conduits: ${GASNet_CONDUITS}")
+    message(STATUS "Found GASNet Threading models: ${GASNet_THREADING_OPTS}")
+  endif()
+endif()
+
+# If found, use the CONDUIT and THREADING options to determine which target to
+# use
+if(GASNet_FOUND AND NOT TARGET GASNet::GASNet)
+  if(NOT GASNet_CONDUIT)
+    list(GET GASNet_CONDUITS 0 GASNet_CONDUIT)
+  endif()
+  set(GASNet_CONDUIT "${GASNet_CONDUIT}" CACHE STRING "GASNet communication conduit to use")
+  mark_as_advanced(GASNet_CONDUIT)
+  set_property(CACHE GASNet_CONDUIT PROPERTY STRINGS ${GASNet_CONDUITS})
+  list(FIND GASNet_CONDUITS "${GASNet_CONDUIT}" _I)
+  if(_I EQUAL -1)
+    message(FATAL_ERROR "Invalid GASNet_CONDUIT setting.  Valid options are: ${GASNet_CONDUITS}")
+  endif()
+
+  set(GASNet_SYSTEM "${GASNet_SYSTEM}" CACHE STRING "system or machine-specific configuration to use for GASNet")
+  mark_as_advanced(GASNet_SYSTEM)
+
+  set(GASNet_THREADING "${GASNet_THREADING}" CACHE STRING "GASNet Threading model to use")
+  mark_as_advanced(GASNet_THREADING)
+  set_property(CACHE GASNet_THREADING PROPERTY STRINGS ${GASNet_THREADING_OPTS})
+  if(NOT GASNet_THREADING)
+    list(GET GASNet_THREADING_OPTS 0 GASNet_THREADING)
+    set(GASNet_THREADING "${GASNet_THREADING}")
+  endif()
+  list(FIND GASNet_THREADING_OPTS "${GASNet_THREADING}" _I)
+  if(_I EQUAL -1)
+    message(FATAL_ERROR "Invalid GASNet_THREADING setting.  Valid options are: ${GASNet_THREADINGS}")
+  endif()
+
+  if(NOT TARGET GASNet::${GASNet_CONDUIT}-${GASNet_THREADING})
+    message(FATAL_ERROR "Unable to use selected CONDUIT-THREADING combination: ${GASNet_CONDUIT}-${GASNet_THREADING}")
+  endif()
+  message(STATUS "GASNet: Using ${GASNet_CONDUIT}-${GASNet_THREADING}")
+  add_library(GASNet::GASNet INTERFACE IMPORTED)
+  set_target_properties(GASNet::GASNet PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS GASNETI_BUG1389_WORKAROUND=1
+    INTERFACE_LINK_LIBRARIES GASNet::${GASNet_CONDUIT}-${GASNet_THREADING}
+  )
+endif()
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(caffeine)

--- a/src/caffeine/CMakeLists.txt
+++ b/src/caffeine/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(prif_sources ${prif_sources}
+  ../prif.F90
+  ./alias_s.F90
+  ./allocation_s.F90
+  ./atomic_s.F90
+  ./co_broadcast_s.F90
+  ./co_max_s.F90
+  ./co_min_s.F90
+  ./co_reduce_s.F90
+  ./co_sum_s.F90
+  ./coarray_access_s.F90
+  ./coarray_queries_s.F90
+  ./critical_s.F90
+  ./events_s.F90
+  ./image_queries_s.F90
+  ./locks_s.F90
+  ./prif_private_s.F90
+  ./program_startup_s.F90
+  ./program_termination_s.F90
+  ./sync_stmt_s.F90
+  ./teams_s.F90
+  ./unit_test_parameters_m.F90
+
+  ./caffeine.c 
+  ../dlmalloc/dl_malloc.c
+)
+
+add_library(caffeine ${prif_sources})


### PR DESCRIPTION
This PR proposes adding a new build system to build the Caffeine library with CMake.
This cmake will also builds required dependencies such as `libassert` and GASNet if they are not found. If not, it will build the dependency from the latest available release indicated in the CMakeLists.txt. 
The `native-mult-image` test is also built if the LLVMFlang compiler is used (currently it is the only one that supports PRIF lowering).

About the `libassert`, for the moment, I'm using `fpm` to build it and assuming that it is available. 
A question remains regarding the use of `fpm` to build `libassert` :
- Should I skip using FPM? 
- Should we add a cmake or other build system in Assert other thant `fpm` and usable by `llvm-test-suite` ? 
- Or any other suggestion ?

Of course, any feedback regarding this PR is welcome.