### PR TITLE
[NO REVIEW] CI: Workaround a recent macOS 26 runner change that broke GASNet build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,10 @@ jobs:
         echo "FC=gfortran-${COMPILER_VERSION}" >> "$GITHUB_ENV"
         echo "CC=gcc-${COMPILER_VERSION}" >> "$GITHUB_ENV"
         echo "CXX=g++-${COMPILER_VERSION}" >> "$GITHUB_ENV"
+        # XCode 26 / gfortran bug workaround
+        if test ${{ matrix.os }} = 'macos-26' ; then \
+          echo "GASNET_CONFIGURE_ARGS=$GASNET_CONFIGURE_ARGS --enable-force-posix-realtime" >> "$GITHUB_ENV" ; \
+        fi
 
     - name: Set flang variables
       if: ${{ matrix.compiler == 'flang' && !matrix.brew_via_install }}
@@ -205,7 +209,6 @@ jobs:
         if (( ${{ matrix.native_multi_image }} )); then \
           echo "FFLAGS=$FFLAGS -DHAVE_MULTI_IMAGE -DHAVE_MULTI_IMAGE_SUPPORT" >> "$GITHUB_ENV" ; \
         fi
-
 
     - name: Checkout code
       uses: actions/checkout@v1
@@ -292,7 +295,7 @@ jobs:
 
     - name: Build Caffeine (install.sh)
       run: |
-        for var in FC CC CXX FFLAGS CPPFLAGS CFLAGS LDFLAGS LIBS GASNET_CONFIGURE_ARGS ; do \
+        for var in FC CC CXX FFLAGS CPPFLAGS CFLAGS CXXFLAGS LDFLAGS LIBS GASNET_CONFIGURE_ARGS ; do \
             eval echo "$var=\$$var"; done
         set -x
         ./install.sh --prefix=${PREFIX} --network=${{ matrix.network }} --verbose


### PR DESCRIPTION
XCode 26.4 [Github runner update](https://github.com/actions/runner-images/commit/17e674feb8e80954e4bbb9504fb618107316559d) broke gfortran (all versions) ability to compile `<mach/mach_time.h>`, resulting in errors like the following:
```
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/message.h:78,
                 from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/host_info.h:66,
                 from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/mach_types.h:80,
                 from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/mach_time.h:32,
                 from ./../../gasnet_timer.h:285,
                 from ./../../gasnet_tools.h:95,
                 from ./../amx/amx_internal_fwd.h:18,
                 from ./amudp_internal.h:9,
                 from ./amudp_spawn.cpp:23:
/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/message.h:299:1: error: expected constructor, destructor, or type conversion before '(' token
  299 | xnu_static_assert_struct_size(mach_msg_type_descriptor_t, 12);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/message.h:308:1: error: expected constructor, destructor, or type conversion before '(' token
  308 | xnu_static_assert_struct_size_kernel_user(mach_msg_port_descriptor_t, 16, 12);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/message.h:319:1: error: expected constructor, destructor, or type conversion before '(' token
  319 | xnu_static_assert_struct_size(mach_msg_ool_descriptor32_t, 12);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/message.h:329:1: error: expected constructor, destructor, or type conversion before '(' token
  329 | xnu_static_assert_struct_size(mach_msg_ool_descriptor64_t, 16);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/mach/message.h:344:1: error: expected constructor, destructor, or type conversion before '(' token
  344 | xnu_static_assert_struct_size_kernel_user64_user32(mach_msg_ool_descriptor_t, 16, 16, 12);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Workaround by disabling the GASNet feature that relies upon that macOS header.

[Bug 4819](https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4819) - g++ failure to build native timers with some versions of macOS XCode 26
