### PR TITLE
Add run-fpm info command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,7 +320,7 @@ jobs:
     ##########################################################################
     # Caffeine Install
 
-    - name: Version info
+    - name: Version info (pre-build)
       run: |
         echo == TOOL VERSIONS ==
         echo Platform version info:
@@ -344,6 +344,10 @@ jobs:
 
     ##########################################################################
     # Caffeine Testing
+
+    - name: Version info (run-fpm)
+      run: |
+        ./run-fpm.sh info
 
     - name: Run examples
       run: |

--- a/install.sh
+++ b/install.sh
@@ -568,13 +568,18 @@ RUN_FPM_SH="run-fpm.sh"
 cat << EOF > $RUN_FPM_SH
 #!/bin/sh
 #-- DO NOT EDIT -- created by caffeine/install.sh
-fpm="${FPM}"
+FPM="${FPM}"
+FC="`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`"
+CC="`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`"
+FFLAGS="$compiler_flag"
+CFLAGS="`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`"
+LDFLAGS="`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`"
 FPM_DRIVER=\${FPM_DRIVER:-\`realpath \$0\`}
 export FPM_DRIVER
 fpm_sub_cmd=\$1; shift
 if echo "--help -help --version -version --list -list new update list clean publish" | grep -w -q -e "\$fpm_sub_cmd" ; then
   set -x
-  exec \$fpm "\$fpm_sub_cmd" "\$@"
+  exec "\$FPM" "\$fpm_sub_cmd" "\$@"
 elif echo "build test run install" | grep -w -q -e "\$fpm_sub_cmd" ; then
   sed -i.bak 's/^link = .*\$/$FPM_TOML_LINK_ENTRY/' $FPM_TOML
   rm -f $FPM_TOML.bak # issue 282: this is the only portable way to use sed -i
@@ -582,17 +587,17 @@ elif echo "build test run install" | grep -w -q -e "\$fpm_sub_cmd" ; then
     set -- "--runner=$GASNET_RUNNER_ARG" "\$@"
   fi
   set -x
-  exec \$fpm "\$fpm_sub_cmd" \\
+  exec "\$FPM" "\$fpm_sub_cmd" \\
   --profile debug \\
-  --flag "$compiler_flag" \\
-  --compiler "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_FC`"   \\
-  --c-compiler "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`" \\
-  --c-flag "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`" \\
-  --link-flag "`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`" \\
+  --compiler "\$FC" \\
+  --flag "\$FFLAGS" \\
+  --c-compiler "\$CC" \\
+  --c-flag "\$CFLAGS" \\
+  --link-flag "\$LDFLAGS" \\
   "\$@"
 else
   echo "ERROR: Unrecognized fpm subcommand \$fpm_sub_cmd"
-  \$fpm list
+  \$FPM list
   exit 1
 fi
 EOF

--- a/install.sh
+++ b/install.sh
@@ -671,6 +671,9 @@ else
   ln -sf "$LIBCAFFEINE_DST" "$PREFIX/lib/libcaffeine.a"
 fi
 
+mkdir -p "$PREFIX/share/caffeine"
+./$RUN_FPM_SH info > "$PREFIX/share/caffeine/caffeine-info-$GASNET_CONDUIT-$GASNET_THREADMODE.txt"
+
 cat << EOF
 
 ________________ Caffeine has been dispensed! ________________

--- a/install.sh
+++ b/install.sh
@@ -595,6 +595,57 @@ elif echo "build test run install" | grep -w -q -e "\$fpm_sub_cmd" ; then
   --c-flag "\$CFLAGS" \\
   --link-flag "\$LDFLAGS" \\
   "\$@"
+elif echo "info" | grep -w -q -e "\$fpm_sub_cmd" ; then
+  LINE=--------------------------------------------------
+  SRCDIR=\$(dirname \$FPM_DRIVER)
+  GASNETDIR="$GASNET_PREFIX"
+  GASNETCONFIG="\$GASNETDIR/include/gasnet_config.h"
+  echo \$LINE
+  echo Version info:
+  echo Caffeine \$(grep version \$SRCDIR/fpm.toml)
+  if test -d \$SRCDIR/.git ; then
+    GITVER=\$( ( cd \$SRCDIR && git describe --long --dirty --always ) 2> /dev/null)
+    if test -n "\$GITVER"; then
+      echo "  git describe: \$GITVER"
+    fi
+  fi
+  if test -r "\$GASNETCONFIG"; then
+    echo GASNet version \$(grep GASNETI_RELEASE_VERSION \$GASNETCONFIG | cut -d' ' -f3-)
+  fi
+  grep -e assert -e julienne \$SRCDIR/fpm.toml
+  echo \$LINE
+  echo Platform info:
+  uname -a
+  if test -r /etc/os-release ; then grep -e NAME -e VERSION /etc/os-release  ; fi
+  if test -x /usr/bin/sw_vers ; then /usr/bin/sw_vers ; fi
+  echo \$LINE
+  echo Install settings:
+  echo ID="\$(date) \$(whoami)"
+  echo PREFIX=$PREFIX
+  echo FPM=\$FPM
+  echo FC=\$FC
+  echo CC=\$CC
+  echo FFLAGS=\$FFLAGS
+  echo CFLAGS=\$FFLAGS
+  echo LDFLAGS=\$LDFLAGS
+  grep -e link \$SRCDIR/fpm.toml
+  echo GASNET=\$GASNETDIR
+  echo GASNET_CONDUIT=$GASNET_CONDUIT
+  echo GASNET_THREADMODE=$GASNET_THREADMODE
+  if test -r "\$GASNETCONFIG"; then
+    grep -e GASNETI_BUILD_ID -e GASNETI_CONFIGURE_ARGS \$GASNETCONFIG | cut -d' ' -f2-
+  fi
+  for tool in FPM FC CC ; do
+    echo \$LINE
+    eval toolval="\\$\$tool"
+    echo \$tool : \$toolval
+    # strip off any arguments that might be embedded:
+    toolval=\$(echo \$toolval | cut -d' ' -f1)
+    eval /bin/ls -al \$toolval
+    eval /bin/ls -alhL \$toolval
+    \$toolval --version
+  done
+  echo \$LINE
 else
   echo "ERROR: Unrecognized fpm subcommand \$fpm_sub_cmd"
   \$FPM list

--- a/install.sh
+++ b/install.sh
@@ -656,7 +656,16 @@ chmod u+x $RUN_FPM_SH
 # for backwards-compatibility of instructions/scripting:
 ( cd build && ln -f -s ../$RUN_FPM_SH run-fpm.sh )
 
-./$RUN_FPM_SH build $VERBOSE
+./$RUN_FPM_SH build $VERBOSE || \
+( set +x
+  echo "Defect reporting information:"
+  ./$RUN_FPM_SH info
+  echo
+  echo Oh no, the Caffeine build appears to have failed!
+  echo Please paste the ENTIRE output above into a new issue here:
+  echo "   https://github.com/berkeleylab/caffeine/issues"
+  exit 1
+)
 
 LIBCAFFEINE_DST=libcaffeine-$GASNET_CONDUIT-$GASNET_THREADMODE.a
 LIBCAFFEINE_SRC=$(./$RUN_FPM_SH install --list 2>/dev/null | grep libcaffeine | cut -d' ' -f2)


### PR DESCRIPTION
## Summary

Fixes #309

Adds a hidden `run-fpm.sh info` command that dumps all sorts of useful configuration information, to assist in triage.

Augment build failures and CI to include the new `run-fpm.sh info` output. 

## Example output

```
$ ./run-fpm.sh info
--------------------------------------------------
Version info:
Caffeine version = "0.7.3"
  git describe: 65c7013
GASNet version 2025.8.0
assert = {git = "https://github.com/berkeleylab/assert.git", tag = "3.1.0"}
julienne = {git = "https://github.com/berkeleylab/julienne.git", tag = "3.6.2"}
--------------------------------------------------
Platform info:
Darwin sjc22-bm204-a3ca91e3-d0d7-4d6b-8783-617d0b361bb6-8A40B903A7B1.local 24.6.0 Darwin Kernel Version 24.6.0: Mon Jan 19 22:02:01 PST 2026; root:xnu-11417.140.69.708.3~1/RELEASE_ARM64_VMAPPLE arm64
ProductName:		macOS
ProductVersion:		15.7.4
BuildVersion:		24G517
--------------------------------------------------
Install settings:
ID=Tue Mar 31 18:55:10 UTC 2026 runner
PREFIX=/Users/runner/work/caffeine/caffeine/install
FPM=/opt/homebrew/bin/fpm
FC=/opt/homebrew/Cellar/flang/22.1.2/libexec/flang-new
CC=/opt/homebrew/opt/llvm/bin/clang
FFLAGS=-g -O3 -DASSERT_MULTI_IMAGE -DASSERT_PARALLEL_CALLBACKS -DHAVE_MULTI_IMAGE_SUPPORT -DJULIENNE_PARALLEL_CALLBACKS -DASSERTIONS -DCAF_NETWORK_SMP -fcoarray -DHAVE_MULTI_IMAGE -DHAVE_MULTI_IMAGE_SUPPORT
CFLAGS=-g -O3 -DASSERT_MULTI_IMAGE -DASSERT_PARALLEL_CALLBACKS -DHAVE_MULTI_IMAGE_SUPPORT -DJULIENNE_PARALLEL_CALLBACKS -DASSERTIONS -DCAF_NETWORK_SMP -fcoarray -DHAVE_MULTI_IMAGE -DHAVE_MULTI_IMAGE_SUPPORT
LDFLAGS=-g -O0 -Wno-unused -Wunused-result -Wno-unused-parameter -Wno-address -L/Users/runner/work/caffeine/caffeine/install/lib
link = ["gasnet-smp-seq"]
GASNET=/Users/runner/work/caffeine/caffeine/install
GASNET_CONDUIT=smp
GASNET_THREADMODE=seq
GASNETI_BUILD_ID "Tue Mar 31 18:54:13 UTC 2026 runner"
GASNETI_CONFIGURE_ARGS "'--prefix=/Users/runner/work/caffeine/caffeine/install' '--enable-rpath' '--enable-debug' '--with-cc=/opt/homebrew/opt/llvm/bin/clang' '--with-cxx=/opt/homebrew/opt/llvm/bin/clang++' '--enable-smp' '--enable-seq' '--enable-par' '--disable-parsync' '--disable-segment-everything' '--disable-mpi-compat'"
--------------------------------------------------
FPM : /opt/homebrew/bin/fpm
lrwxr-xr-x  1 runner  admin  28 Mar 31 18:54 /opt/homebrew/bin/fpm -> ../Cellar/fpm/0.13.0/bin/fpm
-r-xr-xr-x  1 runner  admin    14M Mar 31 18:54 /opt/homebrew/bin/fpm
Version:     0.13.0, alpha
Program:     fpm(1)
Description: A Fortran package manager and build system
Home Page:   https://github.com/fortran-lang/fpm
License:     MIT
OS Type:     macOS
--------------------------------------------------
FC : /opt/homebrew/Cellar/flang/22.1.2/libexec/flang-new
lrwxr-xr-x  1 runner  admin  5 Mar 23 18:46 /opt/homebrew/Cellar/flang/22.1.2/libexec/flang-new -> flang
-rwxr-xr-x  1 runner  admin    99K Mar 31 18:54 /opt/homebrew/Cellar/flang/22.1.2/libexec/flang-new
Homebrew flang version 22.1.2
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /opt/homebrew/Cellar/flang/22.1.2/libexec
Configuration file: /opt/homebrew/Cellar/flang/22.1.2/libexec/flang.cfg
Configuration file: /opt/homebrew/Cellar/flang/22.1.2/etc/clang/arm64-apple-darwin24.cfg
--------------------------------------------------
CC : /opt/homebrew/opt/llvm/bin/clang
lrwxr-xr-x  1 runner  admin  8 Mar 23 18:46 /opt/homebrew/opt/llvm/bin/clang -> clang-22
-r-xr-xr-x  1 runner  admin   135K Mar 23 18:46 /opt/homebrew/opt/llvm/bin/clang
Homebrew clang version 22.1.2
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /opt/homebrew/Cellar/llvm/22.1.2/bin
Configuration file: /opt/homebrew/Cellar/llvm/22.1.2/etc/clang/arm64-apple-darwin24.cfg
--------------------------------------------------
```