### PR TITLE
CI: Add experimental LFortran support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,15 +83,12 @@ jobs:
           - os: ubuntu-22.04
             compiler: lfortran
             version: latest
-            network: smp
             container: ghcr.io/lfortran/lfortran:latest
-            iso_fortran_header: https://raw.githubusercontent.com/lfortran/lfortran/refs/tags/v0.62.0/src/libasr/runtime/ISO_Fortran_binding.h
 
           # https://hub.docker.com/r/phhargrove/lfortran/tags
           - os: ubuntu-24.04
             compiler: lfortran
             version: 0.62
-            network: smp
             container: phhargrove/lfortran:0.62.0-1
             # workaround LFortran issue #11079
             iso_fortran_header: https://raw.githubusercontent.com/lfortran/lfortran/refs/tags/v0.62.0/src/libasr/runtime/ISO_Fortran_binding.h
@@ -181,6 +178,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - name: Install Ubuntu Container Dependencies
+      if: ${{ contains(matrix.os, 'ubuntu') && matrix.container != '' && !contains(matrix.container, 'phhargrove') }}
+      run: |
+        set -x
+        apt update
+        apt install -y build-essential pkg-config make git curl
+
     - name: Set gfortran variables
       if: matrix.compiler == 'gfortran'
       run: |
@@ -211,17 +215,25 @@ jobs:
       run: |
         set -x
         apt update
-        apt install -y llvm clang curl
+        apt install -y llvm clang
+        if [ ${{ contains(matrix.container, 'ghcr.io/lfortran') }} = true ]; then
+          ls -alR /app 
+          # Add container lfortran to PATH:
+          PATH="/app/bin:$PATH"
+          echo "/app/bin" >> "$GITHUB_PATH" 
+        fi
         echo "FC=lfortran" >> "$GITHUB_ENV" 
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
+        HEADER_NAME=ISO_Fortran_binding.h
+        HEADER_TARGET=include/$HEADER_NAME
         if [ -n "${{ matrix.iso_fortran_header }}" ]; then
-          pwd
-          TARGET=include/ISO_Fortran_binding.h
-          curl $CURL_OPTIONS "${{ matrix.iso_fortran_header }}" -o $TARGET
-          ls -al $TARGET
-          find / -name ISO_Fortran_binding.h -print -exec md5sum {} \; ; \
+          curl $CURL_OPTIONS "${{ matrix.iso_fortran_header }}" -o $HEADER_TARGET
+        else
+          HEADER_SOURCE=$(lfortran --print-c-include-dir)/$HEADER_NAME 
+          echo "#include <$HEADER_SOURCE>" > $HEADER_TARGET
         fi
+        find / -name $HEADER_NAME -exec ls -al {} \; -exec md5sum {} \; -exec head {} \; -exec echo --- \;
 
     - name: Set Caffeine variables
       run: |
@@ -264,18 +276,6 @@ jobs:
           echo "CFLAGS=${CFLAGS:+"$CFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
           echo "CXXFLAGS=${CXXFLAGS:+"$CXXFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
           echo "LDFLAGS=${LDFLAGS:+"$LDFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
-        fi
-
-    - name: Install Ubuntu Container Dependencies
-      if: ${{ contains(matrix.os, 'ubuntu') && matrix.container != '' && !contains(matrix.container, 'phhargrove') }}
-      run: |
-        set -x
-        apt update
-        apt install -y build-essential pkg-config make git curl
-        # Add container lfortran to PATH:
-        if test "$FC" = "lfortran"; then \
-          ls -alR /app ; \
-          echo "/app/bin" >> "$GITHUB_PATH" ; \
         fi
 
     - name: Install macOS Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ defaults:
 
 jobs:
   build:
-    name: ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.network }} (${{ matrix.os }}) ${{ matrix.label }}
+    name: ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.network || '' }} (${{ matrix.os }}) ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -16,42 +16,36 @@ jobs:
         os: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel, ubuntu-24.04 ]
         compiler: [ gfortran ]
         version: [ 13, 14, 15 ]
-        network: [ smp ]
         include:
 
         # --- flang coverage ---
           - os: macos-14
             compiler: flang
             version: 22
-            network: smp
             native_multi_image: 1
             brew_via_install: 1
             FFLAGS: -fcoarray
           - os: macos-15
             compiler: flang
             version: 22
-            network: smp
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-15-intel
             compiler: flang
             version: 22
-            network: smp
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-26
             compiler: flang
             version: 22
-            network: smp
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-26-intel
             compiler: flang
             version: 22
-            network: smp
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
@@ -59,7 +53,6 @@ jobs:
           - os: ubuntu-24.04
             compiler: flang
             version: 22
-            network: smp
             label: Homebrew
             brew_via_install: 1
             native_multi_image: 1
@@ -69,7 +62,6 @@ jobs:
           - os: ubuntu-24.04
             compiler: flang
             version: latest
-            network: smp
             native_multi_image: 1
             FFLAGS: -fcoarray
             container: snowstep/llvm:ubuntu-24.04-latest
@@ -78,24 +70,20 @@ jobs:
           - os: ubuntu-24.04
             compiler: flang
             version: 22
-            network: smp
             native_multi_image: 1
             FFLAGS: -fcoarray
             container: phhargrove/llvm-flang:22.1.3-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 21
-            network: smp
             container: phhargrove/llvm-flang:21.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 20
-            network: smp
             container: phhargrove/llvm-flang:20.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 19
-            network: smp
             FFLAGS: -mmlir -allow-assumed-rank
             container: phhargrove/llvm-flang:19.1.1-latest
 
@@ -103,14 +91,12 @@ jobs:
           - os: ubuntu-24.04
             compiler: flang
             version: 21
-            network: smp
             label: PRIF-0.5
             FFLAGS: -DFORCE_PRIF_0_5
             container: phhargrove/llvm-flang:21.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 21
-            network: smp
             label: PRIF-0.6
             FFLAGS: -DFORCE_PRIF_0_6
             container: phhargrove/llvm-flang:21.1.0-latest
@@ -187,6 +173,7 @@ jobs:
       COMPILER_VERSION: ${{ matrix.version }}
       FFLAGS: ${{ matrix.FFLAGS }}
       PREFIX: install
+      NETWORK_ARG: ${{ matrix.network && format('--network={0}',matrix.network) || '' }}
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
       GASNET_SPAWN_VERBOSE: 1
       GASNET_SPAWNFN: L
@@ -320,7 +307,7 @@ jobs:
         for var in FC CC CXX FFLAGS CPPFLAGS CFLAGS CXXFLAGS LDFLAGS LIBS GASNET_CONFIGURE_ARGS ; do \
             eval echo "$var=\$$var"; done
         set -x
-        ./install.sh --prefix=${PREFIX} --network=${{ matrix.network }} --verbose
+        ./install.sh --prefix=${PREFIX} ${NETWORK_ARG} --verbose
 
     - name: Run examples
       run: |
@@ -380,6 +367,6 @@ jobs:
         for var in FC CC CXX FFLAGS CPPFLAGS CFLAGS LDFLAGS LIBS GASNET_CONFIGURE_ARGS ; do \
             eval echo "$var=\$$var"; done
         set -x
-        ./install.sh --prefix=${PREFIX} --network=${{ matrix.network }} --enable-threads --verbose
+        ./install.sh --prefix=${PREFIX} ${NETWORK_ARG} --enable-threads --verbose
         ./run-fpm.sh test --verbose --
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,25 @@ jobs:
             FFLAGS: -mmlir -allow-assumed-rank
             container: phhargrove/llvm-flang:19.1.1-latest
 
+        # --- lfortran coverage ---
+
+          # https://github.com/lfortran/lfortran/pkgs/container/lfortran
+          - os: ubuntu-22.04
+            compiler: lfortran
+            version: latest
+            network: smp
+            container: ghcr.io/lfortran/lfortran:latest
+            iso_fortran_header: https://raw.githubusercontent.com/lfortran/lfortran/refs/tags/v0.62.0/src/libasr/runtime/ISO_Fortran_binding.h
+
+          # https://hub.docker.com/r/phhargrove/lfortran/tags
+          - os: ubuntu-24.04
+            compiler: lfortran
+            version: 0.62
+            network: smp
+            container: phhargrove/lfortran:0.62.0-1
+            # workaround LFortran issue #11079
+            iso_fortran_header: https://raw.githubusercontent.com/lfortran/lfortran/refs/tags/v0.62.0/src/libasr/runtime/ISO_Fortran_binding.h
+
         # --- PRIF-old coverage ---
           - os: ubuntu-24.04
             compiler: flang
@@ -151,6 +170,7 @@ jobs:
       FFLAGS: ${{ matrix.FFLAGS }}
       PREFIX: install
       NETWORK_ARG: ${{ matrix.network && format('--network={0}',matrix.network) || '' }}
+      CURL_OPTIONS: -L --retry 10 --retry-all-errors --fail 
       GASNET_CONFIGURE_ARGS: --enable-rpath --enable-debug
       GASNET_SPAWN_VERBOSE: 1
       GASNET_SPAWNFN: L
@@ -158,6 +178,9 @@ jobs:
       CAF_IMAGES: 8
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+
     - name: Set gfortran variables
       if: matrix.compiler == 'gfortran'
       run: |
@@ -183,6 +206,23 @@ jobs:
           echo "FFLAGS=$FFLAGS -fcoarray" >> "$GITHUB_ENV"
         fi
 
+    - name: Setup lfortran dependencies and variables
+      if: ${{ matrix.compiler == 'lfortran' }}
+      run: |
+        set -x
+        apt update
+        apt install -y llvm clang curl
+        echo "FC=lfortran" >> "$GITHUB_ENV" 
+        echo "CC=clang" >> "$GITHUB_ENV"
+        echo "CXX=clang++" >> "$GITHUB_ENV"
+        if [ -n "${{ matrix.iso_fortran_header }}" ]; then
+          pwd
+          TARGET=include/ISO_Fortran_binding.h
+          curl $CURL_OPTIONS "${{ matrix.iso_fortran_header }}" -o $TARGET
+          ls -al $TARGET
+          find / -name ISO_Fortran_binding.h -print -exec md5sum {} \; ; \
+        fi
+
     - name: Set Caffeine variables
       run: |
         set -x
@@ -201,9 +241,6 @@ jobs:
           echo "FFLAGS=$FFLAGS -DHAVE_MULTI_IMAGE -DHAVE_MULTI_IMAGE_SUPPORT" >> "$GITHUB_ENV" ; \
         fi
 
-    - name: Checkout code
-      uses: actions/checkout@v1
-
     - name: Install Ubuntu Native Dependencies
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.container == '' && !matrix.brew_via_install }}
       run: |
@@ -213,7 +250,7 @@ jobs:
         if [[ ${COMPILER_VERSION} < 15 ]] ; then \
           sudo apt install -y gfortran-${COMPILER_VERSION} g++-${COMPILER_VERSION} ; \
         else \
-          curl -L https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o install-homebrew.sh ; \
+          curl $CURL_OPTIONS https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o install-homebrew.sh ; \
           chmod +x install-homebrew.sh ; \
           env CI=1 ./install-homebrew.sh ; \
           HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" ; \
@@ -235,6 +272,11 @@ jobs:
         set -x
         apt update
         apt install -y build-essential pkg-config make git curl
+        # Add container lfortran to PATH:
+        if test "$FC" = "lfortran"; then \
+          ls -alR /app ; \
+          echo "/app/bin" >> "$GITHUB_PATH" ; \
+        fi
 
     - name: Install macOS Dependencies
       if: ${{ contains(matrix.os, 'macos') && !matrix.brew_via_install }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,20 @@ defaults:
     shell: bash
 
 jobs:
+  setup: # establish default configuration values, independent of repo/org
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs: 
+      # The LLVM Flang version on Homebrew : https://formulae.brew.sh/formula/flang
+      BREW_FLANG_VERSION: ${{ steps.vars.outputs.BREW_FLANG_VERSION }}
+    steps:
+      - name: Set default configuration variables
+        id: vars
+        run: echo "BREW_FLANG_VERSION=22" >> $GITHUB_OUTPUT
+
   build:
-    name: ${{ matrix.compiler }}-${{ matrix.version }} ${{ matrix.network || '' }} (${{ matrix.os }}) ${{ matrix.label }}
+    name: ${{ matrix.compiler }}-${{ matrix.version || needs.setup.outputs.BREW_FLANG_VERSION }} ${{ matrix.network || '' }} (${{ matrix.os }}) ${{ matrix.label }}
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -21,38 +33,32 @@ jobs:
         # --- flang coverage ---
           - os: macos-14
             compiler: flang
-            version: 22
             native_multi_image: 1
             brew_via_install: 1
             FFLAGS: -fcoarray
           - os: macos-15
             compiler: flang
-            version: 22
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-15-intel
             compiler: flang
-            version: 22
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-26
             compiler: flang
-            version: 22
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-26-intel
             compiler: flang
-            version: 22
             brew_via_install: 1
             native_multi_image: 1
             FFLAGS: -fcoarray
 
           - os: ubuntu-24.04
             compiler: flang
-            version: 22
             label: Homebrew
             brew_via_install: 1
             native_multi_image: 1
@@ -118,25 +124,21 @@ jobs:
 
           - os: macos-15-intel
             compiler: flang
-            version: 22
             network: udp
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-15
             compiler: flang
-            version: 22
             network: udp
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-26-intel
             compiler: flang
-            version: 22
             network: udp
             native_multi_image: 1
             FFLAGS: -fcoarray
           - os: macos-26
             compiler: flang
-            version: 22
             network: udp
             native_multi_image: 1
             FFLAGS: -fcoarray
@@ -170,7 +172,7 @@ jobs:
       image: ${{ matrix.container }}
 
     env:
-      COMPILER_VERSION: ${{ matrix.version }}
+      COMPILER_VERSION: ${{ matrix.version || needs.setup.outputs.BREW_FLANG_VERSION }}
       FFLAGS: ${{ matrix.FFLAGS }}
       PREFIX: install
       NETWORK_ARG: ${{ matrix.network && format('--network={0}',matrix.network) || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,51 +33,35 @@ jobs:
         # --- flang coverage ---
           - os: macos-14
             compiler: flang
-            native_multi_image: 1
             brew_via_install: 1
-            FFLAGS: -fcoarray
           - os: macos-15
             compiler: flang
             brew_via_install: 1
-            native_multi_image: 1
-            FFLAGS: -fcoarray
           - os: macos-15-intel
             compiler: flang
             brew_via_install: 1
-            native_multi_image: 1
-            FFLAGS: -fcoarray
           - os: macos-26
             compiler: flang
             brew_via_install: 1
-            native_multi_image: 1
-            FFLAGS: -fcoarray
           - os: macos-26-intel
             compiler: flang
             brew_via_install: 1
-            native_multi_image: 1
-            FFLAGS: -fcoarray
 
           - os: ubuntu-24.04
             compiler: flang
             label: Homebrew
             brew_via_install: 1
-            native_multi_image: 1
-            FFLAGS: -fcoarray
 
           # https://hub.docker.com/r/snowstep/llvm/tags
           - os: ubuntu-24.04
             compiler: flang
             version: latest
-            native_multi_image: 1
-            FFLAGS: -fcoarray
             container: snowstep/llvm:ubuntu-24.04-latest
 
           # https://hub.docker.com/r/phhargrove/llvm-flang/tags
           - os: ubuntu-24.04
             compiler: flang
             version: 22
-            native_multi_image: 1
-            FFLAGS: -fcoarray
             container: phhargrove/llvm-flang:22.1.3-latest
           - os: ubuntu-24.04
             compiler: flang
@@ -125,23 +109,15 @@ jobs:
           - os: macos-15-intel
             compiler: flang
             network: udp
-            native_multi_image: 1
-            FFLAGS: -fcoarray
           - os: macos-15
             compiler: flang
             network: udp
-            native_multi_image: 1
-            FFLAGS: -fcoarray
           - os: macos-26-intel
             compiler: flang
             network: udp
-            native_multi_image: 1
-            FFLAGS: -fcoarray
           - os: macos-26
             compiler: flang
             network: udp
-            native_multi_image: 1
-            FFLAGS: -fcoarray
 
           - os: ubuntu-24.04
             compiler: flang
@@ -157,15 +133,11 @@ jobs:
             compiler: flang
             version: 22
             network: udp
-            native_multi_image: 1
-            FFLAGS: -fcoarray
             container: phhargrove/llvm-flang:22.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: latest
             network: udp
-            native_multi_image: 1
-            FFLAGS: -fcoarray
             container: snowstep/llvm:ubuntu-24.04-latest
 
     container:
@@ -173,6 +145,9 @@ jobs:
 
     env:
       COMPILER_VERSION: ${{ matrix.version || needs.setup.outputs.BREW_FLANG_VERSION }}
+      NATIVE_MULTI_IMAGE: ${{ matrix.native_multi_image || 
+          ( matrix.compiler == 'flang' && ( ! matrix.version || matrix.version >= 22 || matrix.version == 'latest' ) ) 
+        }}
       FFLAGS: ${{ matrix.FFLAGS }}
       PREFIX: install
       NETWORK_ARG: ${{ matrix.network && format('--network={0}',matrix.network) || '' }}
@@ -196,12 +171,17 @@ jobs:
         fi
 
     - name: Set flang variables
-      if: ${{ matrix.compiler == 'flang' && !matrix.brew_via_install }}
+      if: ${{ matrix.compiler == 'flang' }}
       run: |
         set -x
-        echo "FC=flang-new" >> "$GITHUB_ENV" 
-        echo "CC=clang" >> "$GITHUB_ENV"
-        echo "CXX=clang++" >> "$GITHUB_ENV"
+        if [ -z "${{ matrix.brew_via_install }}" ] ; then
+          echo "FC=flang-new" >> "$GITHUB_ENV" 
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+        fi
+        if [ "${NATIVE_MULTI_IMAGE}" == true ] ; then
+          echo "FFLAGS=$FFLAGS -fcoarray" >> "$GITHUB_ENV"
+        fi
 
     - name: Set Caffeine variables
       run: |
@@ -217,7 +197,7 @@ jobs:
         # Turn some knobs for a compiler that natively uses PRIF for multi-image features:
         # HAVE_MULTI_IMAGE : controls app/native-multi-image and prif_init testing
         # HAVE_MULTI_IMAGE_SUPPORT : force-enable Julienne's multi-image support
-        if (( ${{ matrix.native_multi_image }} )); then \
+        if [ "${NATIVE_MULTI_IMAGE}" == true ] ; then
           echo "FFLAGS=$FFLAGS -DHAVE_MULTI_IMAGE -DHAVE_MULTI_IMAGE_SUPPORT" >> "$GITHUB_ENV" ; \
         fi
 
@@ -318,7 +298,7 @@ jobs:
         ./run-fpm.sh run --verbose --example hello
 
     - name: Run native multi-image test
-      if: ${{ matrix.native_multi_image }}
+      if: ${{ env.NATIVE_MULTI_IMAGE == 'true' }}
       run: |
         set -x ; ./run-fpm.sh run --verbose 2>&1 | tee output ; \
           test ${PIPESTATUS[0]} = 0 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,12 +178,76 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    ##########################################################################
+    # Establish Dependencies
+
     - name: Install Ubuntu Container Dependencies
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.container != '' && !contains(matrix.container, 'phhargrove') }}
       run: |
         set -x
         apt update
         apt install -y build-essential pkg-config make git curl
+
+    - name: Install Ubuntu Native Dependencies
+      if: ${{ contains(matrix.os, 'ubuntu') && matrix.container == '' && !matrix.brew_via_install }}
+      run: |
+        set -x
+        sudo apt update
+        sudo apt install -y build-essential pkg-config make
+        if [[ ${COMPILER_VERSION} < 15 ]] ; then \
+          sudo apt install -y gfortran-${COMPILER_VERSION} g++-${COMPILER_VERSION} ; \
+        else \
+          curl $CURL_OPTIONS https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o install-homebrew.sh ; \
+          chmod +x install-homebrew.sh ; \
+          env CI=1 ./install-homebrew.sh ; \
+          HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" ; \
+          ${HOMEBREW_PREFIX}/bin/brew install -v gcc@${COMPILER_VERSION} binutils ; \
+          ls -al ${HOMEBREW_PREFIX}/bin ; \
+          echo "PATH=${HOMEBREW_PREFIX}/bin:${PATH}" >> "$GITHUB_ENV" ; \
+          : Homebrew GCC@15 needs binutils 2.44+ ; \
+          HOMEBREW_BINUTILS=$(ls -d ${HOMEBREW_PREFIX}/Cellar/binutils/2.*/bin ) ; \
+          ls -al ${HOMEBREW_BINUTILS} ; \
+          echo "FFLAGS=${FFLAGS:+"$FFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          echo "CFLAGS=${CFLAGS:+"$CFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          echo "CXXFLAGS=${CXXFLAGS:+"$CXXFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          echo "LDFLAGS=${LDFLAGS:+"$LDFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+        fi
+
+    - name: Install macOS Dependencies
+      if: ${{ contains(matrix.os, 'macos') && !matrix.brew_via_install }}
+      run: |
+        set -x
+        brew update
+        # fpm binary distribution for macOS requires gfortran shared libraries from gcc@12
+        brew install gcc@12
+
+    - name: Install LLVM flang on macOS
+      if: ${{ contains(matrix.os, 'macos') && matrix.compiler == 'flang' && !matrix.brew_via_install }}
+      run: |
+        set -x
+        brew install llvm@${COMPILER_VERSION} flang
+        # Prepend homebrew clang to PATH:
+        echo "PATH=$(brew --prefix)/opt/llvm/bin:${PATH}" >> "$GITHUB_ENV"
+
+    - name: Setup FPM
+      if: ${{ !matrix.brew_via_install }}
+      uses: fortran-lang/setup-fpm@main
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fpm-version: latest
+
+    - name: Build FPM
+      if: false
+      run: |
+        set -x
+        export FPM_VERSION=0.12.0
+        curl --retry 5 -LOsS https://github.com/fortran-lang/fpm/releases/download/v$FPM_VERSION/fpm-$FPM_VERSION.F90
+        mkdir fpm-temp
+        gfortran-14 -o fpm-temp/fpm fpm-$FPM_VERSION.F90
+        echo "PATH=${PWD}/fpm-temp:${PATH}" >> "$GITHUB_ENV"
+
+    ##########################################################################
+    # Set Install Variables
 
     - name: Set gfortran variables
       if: matrix.compiler == 'gfortran'
@@ -253,63 +317,8 @@ jobs:
           echo "FFLAGS=$FFLAGS -DHAVE_MULTI_IMAGE -DHAVE_MULTI_IMAGE_SUPPORT" >> "$GITHUB_ENV" ; \
         fi
 
-    - name: Install Ubuntu Native Dependencies
-      if: ${{ contains(matrix.os, 'ubuntu') && matrix.container == '' && !matrix.brew_via_install }}
-      run: |
-        set -x
-        sudo apt update
-        sudo apt install -y build-essential pkg-config make
-        if [[ ${COMPILER_VERSION} < 15 ]] ; then \
-          sudo apt install -y gfortran-${COMPILER_VERSION} g++-${COMPILER_VERSION} ; \
-        else \
-          curl $CURL_OPTIONS https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o install-homebrew.sh ; \
-          chmod +x install-homebrew.sh ; \
-          env CI=1 ./install-homebrew.sh ; \
-          HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" ; \
-          ${HOMEBREW_PREFIX}/bin/brew install -v gcc@${COMPILER_VERSION} binutils ; \
-          ls -al ${HOMEBREW_PREFIX}/bin ; \
-          echo "PATH=${HOMEBREW_PREFIX}/bin:${PATH}" >> "$GITHUB_ENV" ; \
-          : Homebrew GCC@15 needs binutils 2.44+ ; \
-          HOMEBREW_BINUTILS=$(ls -d ${HOMEBREW_PREFIX}/Cellar/binutils/2.*/bin ) ; \
-          ls -al ${HOMEBREW_BINUTILS} ; \
-          echo "FFLAGS=${FFLAGS:+"$FFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
-          echo "CFLAGS=${CFLAGS:+"$CFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
-          echo "CXXFLAGS=${CXXFLAGS:+"$CXXFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
-          echo "LDFLAGS=${LDFLAGS:+"$LDFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
-        fi
-
-    - name: Install macOS Dependencies
-      if: ${{ contains(matrix.os, 'macos') && !matrix.brew_via_install }}
-      run: |
-        set -x
-        brew update
-        # fpm binary distribution for macOS requires gfortran shared libraries from gcc@12
-        brew install gcc@12
-
-    - name: Install LLVM flang on macOS
-      if: ${{ contains(matrix.os, 'macos') && matrix.compiler == 'flang' && !matrix.brew_via_install }}
-      run: |
-        set -x
-        brew install llvm@${COMPILER_VERSION} flang
-        # Prepend homebrew clang to PATH:
-        echo "PATH=$(brew --prefix)/opt/llvm/bin:${PATH}" >> "$GITHUB_ENV"
-
-    - name: Setup FPM
-      if: ${{ !matrix.brew_via_install }}
-      uses: fortran-lang/setup-fpm@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        fpm-version: latest
-
-    - name: Build FPM
-      if: false
-      run: |
-        set -x
-        export FPM_VERSION=0.12.0
-        curl --retry 5 -LOsS https://github.com/fortran-lang/fpm/releases/download/v$FPM_VERSION/fpm-$FPM_VERSION.F90
-        mkdir fpm-temp
-        gfortran-14 -o fpm-temp/fpm fpm-$FPM_VERSION.F90
-        echo "PATH=${PWD}/fpm-temp:${PATH}" >> "$GITHUB_ENV"
+    ##########################################################################
+    # Caffeine Install
 
     - name: Version info
       run: |
@@ -332,6 +341,9 @@ jobs:
             eval echo "$var=\$$var"; done
         set -x
         ./install.sh --prefix=${PREFIX} ${NETWORK_ARG} --verbose
+
+    ##########################################################################
+    # Caffeine Testing
 
     - name: Run examples
       run: |

--- a/install.sh
+++ b/install.sh
@@ -521,7 +521,7 @@ if [[ $compiler_version =~ 'flang' ]]; then
 elif [[ $compiler_version =~ 'GNU Fortran' ]]; then
   compiler_flag="-g -O3 -ffree-line-length-0 -Wno-unused-dummy-argument"
 elif [[ $compiler_version =~ 'LFortran' ]]; then
-  compiler_flag="-g -O3 --cpp"
+  compiler_flag="-O3 --cpp --realloc-lhs-arrays --separate-compilation --no-style-suggestions --implicit-argument-casting"
 else # unknown compiler
   compiler_flag="-g -O2"
   echo "WARNING: Failed to detect a recognized Fortran compiler"

--- a/src/caffeine/events_s.F90
+++ b/src/caffeine/events_s.F90
@@ -36,7 +36,7 @@ contains
     integer(c_int64_t) :: threshold
 
     if (present(until_count)) then
-      threshold = MAX(until_count, 1)
+      threshold = MAX(until_count, 1_c_int64_t)
     else
       threshold = 1
     endif
@@ -56,7 +56,7 @@ contains
     integer(c_int64_t) :: threshold
 
     if (present(until_count)) then
-      threshold = MAX(until_count, 1)
+      threshold = MAX(until_count, 1_c_int64_t)
     else
       threshold = 1
     endif

--- a/test/prif_allocate_test.F90
+++ b/test/prif_allocate_test.F90
@@ -213,7 +213,7 @@ contains
     type(c_ptr) :: allocated_memory
     integer(c_int), pointer :: local_slice
 
-    call prif_allocate(sizeof(local_slice), allocated_memory)
+    call prif_allocate(c_sizeof(local_slice), allocated_memory)
     call c_f_pointer(allocated_memory, local_slice)
 
     local_slice = 42

--- a/test/prif_atomic_test.F90
+++ b/test/prif_atomic_test.F90
@@ -316,7 +316,7 @@ contains
         integer(c_intptr_t) :: base_addr_int, base_addr_logical
         integer(PRIF_ATOMIC_INT_KIND), parameter :: zero = 0, plus_one = 1, minus_one = -1
         integer(PRIF_ATOMIC_INT_KIND) :: value_int, expect_int, tmp_int, my_bit
-        logical(PRIF_ATOMIC_LOGICAL_KIND) :: false = .false.
+        logical(PRIF_ATOMIC_LOGICAL_KIND), parameter :: false = .false.
         logical(PRIF_ATOMIC_LOGICAL_KIND) :: value_logical, expect_logical, tmp_logical
         character(len=:),allocatable :: desc
 


### PR DESCRIPTION
Minor script and code adjustments to accommodate LFortran version 0.62 and latest, which are now capable of building Caffeine (under the right conditions). Add LFortran to CI on Linux to help prevent bitrot. LFortran support remains deliberately undocumented for now.

Also deploy some factorization in the workflow definition file to ease maintenance.