### PR TITLE
[NO REVIEW] CI: Deploy concurrency and path filtering for Action activation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,18 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore: &paths_ignore
+      - 'docs/**'
+      - '**.txt'
+      - '**.md'
+  pull_request:
+    paths-ignore: *paths_ignore
+
+concurrency:
+  # De-duplicate concurrent workflow runs on the same branch/ref
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 defaults:
   run:


### PR DESCRIPTION
Reduce unnecessary churn by skipping CI Action for documentation-only changes.

Also, avoid duplicate Actions on pushes to PR branches (which trigger both the `push` and `pull_request` events).

Finally, cancel earlier Actions still running when a non-main branch is updated, as these are usually unneeded, and the superceded Action can even cause spurious failures after a subsequent force push orphans the source commit.