### PR TITLE
[NO REVIEW] CI: Enable native testing for lfortran:latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,8 @@ jobs:
             compiler: lfortran
             version: latest
             container: ghcr.io/lfortran/lfortran:latest
+            native_multi_image: true
+            FFLAGS: --coarray=true -DHAVE_SYNC=0 -DHAVE_COLLECTIVES=0 -DHAVE_TEAM=0
 
           - os: ubuntu-22.04
             compiler: lfortran


### PR DESCRIPTION
With the merge of https://github.com/lfortran/lfortran/pull/11656 , we can now enable minimal end-to-end native multi-image testing in `lfortran-latest`  🥇 