### PR TITLE
Julienne 4.0 adjustments

### DIFF
--- a/manifest/fpm.toml.template
+++ b/manifest/fpm.toml.template
@@ -7,7 +7,7 @@ copyright = "2021-2026 The Regents of the University of California, through Lawr
 
 [dev-dependencies]
 assert = {git = "https://github.com/berkeleylab/assert.git", tag = "3.1.0"}
-julienne = {git = "https://github.com/berkeleylab/julienne.git", tag = "3.6.2"}
+julienne = {git = "https://github.com/berkeleylab/julienne.git", tag = "4.1.0"}
 
 [install]
 library = true

--- a/test/julienne-driver.F90
+++ b/test/julienne-driver.F90
@@ -4,7 +4,7 @@
 program test_suite_driver
   use julienne_m
   use prif, only: prif_this_image_no_coarray, prif_num_images, prif_sync_all, prif_co_sum, prif_error_stop
-  use iso_c_binding, only: c_int, c_bool
+  use iso_c_binding, only: c_int, c_bool, c_funloc, c_funptr, c_f_procpointer
   use prif_init_test_m, only : prif_init_test_t, check_caffeination
   use prif_num_images_test_m, only : prif_num_images_test_t
   use prif_this_image_no_coarray_test_m, only : prif_this_image_no_coarray_test_t
@@ -33,13 +33,7 @@ program test_suite_driver
   type(test_diagnosis_t) :: dummy
   dummy = check_caffeination() ! ensure an early call to prif_init
 
-# if JULIENNE_PARALLEL_CALLBACKS
-    julienne_this_image => julienne_callback_this_image
-    julienne_num_images => julienne_callback_num_images
-    julienne_sync_all => julienne_callback_sync_all
-    julienne_co_sum_integer => julienne_callback_co_sum_integer
-    julienne_error_stop => julienne_callback_error_stop
-# endif
+  call setup_julienne_callbacks()
 
   associate(test_harness => test_harness_t([ &
     ! tests for basic functionality that are mostly self-contained
@@ -120,6 +114,21 @@ contains
     character(len=*), intent(in) :: stop_code_char
     
     call prif_error_stop(quiet=.false._c_bool, stop_code_char=stop_code_char)    
+  end subroutine
+
+  subroutine setup_julienne_callbacks()
+    implicit none
+# if JULIENNE_PARALLEL_CALLBACKS
+    type(c_funptr) :: funloc_error_stop
+
+    julienne_this_image => julienne_callback_this_image
+    julienne_num_images => julienne_callback_num_images
+    julienne_sync_all => julienne_callback_sync_all
+    julienne_co_sum_integer => julienne_callback_co_sum_integer
+
+    funloc_error_stop = c_funloc(julienne_callback_error_stop)
+    call c_f_procpointer(funloc_error_stop, julienne_error_stop) ! purify
+# endif
   end subroutine
 
 end program test_suite_driver


### PR DESCRIPTION
Julienne 4.x includes a breaking changes to Caffeine's use case. 

- [x] Deploy a workaround
- [x] Bump Julienne dependency to new version
