### PR TITLE
Add assertions along all PRIF entry points that prif_init has been called

### DIFF
--- a/src/caffeine/allocation_s.F90
+++ b/src/caffeine/allocation_s.F90
@@ -43,6 +43,7 @@ contains
     integer(c_int) :: corank
     type(prif_coarray_descriptor), pointer :: cdp
 
+    call_assert(prif_init_called_previously)
     call_assert(team_check(current_team))
 
     corank = size(lcobounds)
@@ -137,6 +138,8 @@ contains
   module procedure prif_allocate
     type(c_ptr) :: mem
 
+    call_assert(prif_init_called_previously)
+
     mem = caf_allocate_non_symmetric(size_in_bytes)
     if (.not. c_associated(mem)) then
       call report_error(PRIF_STAT_OUT_OF_MEMORY, out_of_memory_message(size_in_bytes, .false.), &
@@ -208,6 +211,7 @@ contains
       character(len=:), allocatable :: local_errmsg
 #   endif
 
+    call_assert(prif_init_called_previously)
     call prif_sync_all ! Need to ensure we don't deallocate anything till everyone gets here
     num_handles = size(coarray_handles)
     if (.not. all([(c_associated(coarray_handles(i)%info), i = 1, num_handles)])) then
@@ -258,6 +262,7 @@ contains
   end procedure
 
   module procedure prif_deallocate
+    call_assert(prif_init_called_previously)
     call caf_deallocate_non_symmetric(mem)
     if (present(stat)) stat = 0
   end procedure

--- a/src/caffeine/co_broadcast_s.F90
+++ b/src/caffeine/co_broadcast_s.F90
@@ -11,6 +11,7 @@ submodule(prif:prif_private_s)  co_broadcast_s
 contains
 
   module procedure prif_co_broadcast
+    call_assert(prif_init_called_previously)
     call_assert(source_image >= 1 .and. source_image <= current_team%info%num_images)
     call contiguous_co_broadcast(a, source_image, stat, errmsg, errmsg_alloc)
   end procedure
@@ -29,6 +30,7 @@ contains
   end subroutine
 
   module procedure prif_co_broadcast_cptr
+    call_assert(prif_init_called_previously)
     call_assert(source_image >= 1 .and. source_image <= current_team%info%num_images)
     if (present(stat)) stat=0
     call caf_co_broadcast_cptr(a_ptr, source_image, size_in_bytes, current_team%info%gex_team)

--- a/src/caffeine/co_max_s.F90
+++ b/src/caffeine/co_max_s.F90
@@ -40,6 +40,7 @@ submodule(prif:prif_private_s) co_max_s
 contains
 
   module procedure prif_co_max
+    call_assert(prif_init_called_previously)
     if (present(result_image)) then
       call_assert(result_image >= 1 .and. result_image <= current_team%info%num_images)
     endif
@@ -68,6 +69,7 @@ contains
     integer(c_size_t), target :: char_len
     procedure(prif_operation_wrapper_interface), pointer :: op
 
+    call_assert(prif_init_called_previously)
     char_len = len(a)
     op => caf_char_max_wrapper
 #if defined(__GFORTRAN__) && 0

--- a/src/caffeine/co_min_s.F90
+++ b/src/caffeine/co_min_s.F90
@@ -40,6 +40,7 @@ submodule(prif:prif_private_s) co_min_s
 contains
 
   module procedure prif_co_min
+    call_assert(prif_init_called_previously)
     if (present(result_image)) then
       call_assert(result_image >= 1 .and. result_image <= current_team%info%num_images)
     endif
@@ -68,6 +69,7 @@ contains
     integer(c_size_t), target :: char_len
     procedure(prif_operation_wrapper_interface), pointer :: op
 
+    call_assert(prif_init_called_previously)
     char_len = len(a)
     op => caf_char_min_wrapper
 #if defined(__GFORTRAN__) && 0

--- a/src/caffeine/co_reduce_s.F90
+++ b/src/caffeine/co_reduce_s.F90
@@ -18,6 +18,7 @@ contains
     integer(c_int), intent(out), optional :: stat
     character(len=*), intent(inout), optional :: errmsg
     character(len=:), intent(inout), allocatable, optional :: errmsg_alloc
+    call_assert(prif_init_called_previously)
     if (present(result_image)) then
       call_assert(result_image >= 1 .and. result_image <= current_team%info%num_images)
     endif
@@ -63,6 +64,7 @@ contains
     character(len=:), intent(inout), allocatable, optional :: errmsg_alloc
     type(c_funptr) :: funptr 
 
+    call_assert(prif_init_called_previously)
     if (present(stat)) stat=0
 
     call_assert(associated(operation_wrapper))

--- a/src/caffeine/co_sum_s.F90
+++ b/src/caffeine/co_sum_s.F90
@@ -11,6 +11,7 @@ submodule(prif:prif_private_s) co_sum_s
 contains
 
   module procedure prif_co_sum
+    call_assert(prif_init_called_previously)
     if (present(result_image)) then
       call_assert(result_image >= 1 .and. result_image <= current_team%info%num_images)
     endif

--- a/src/caffeine/coarray_access_s.F90
+++ b/src/caffeine/coarray_access_s.F90
@@ -26,6 +26,7 @@ contains
   end procedure
 
   module procedure prif_put_indirect
+    call_assert(prif_init_called_previously)
     call_assert_describe(image_num > 0 .and. image_num <= initial_team%num_images, "image_num not within valid range")
 
     call caf_put( &
@@ -87,6 +88,7 @@ contains
   end procedure
 
   module procedure prif_put_indirect_with_notify_indirect
+    call_assert(prif_init_called_previously)
     call_assert_describe(image_num > 0 .and. image_num <= initial_team%num_images, "image_num not within valid range")
 
     call caf_put( &
@@ -118,6 +120,7 @@ contains
   end procedure
 
   module procedure prif_get_indirect
+    call_assert(prif_init_called_previously)
     call_assert_describe(image_num > 0 .and. image_num <= initial_team%num_images, "image_num not within valid range")
 
     call caf_get( &
@@ -183,6 +186,7 @@ contains
   end procedure
 
   module procedure prif_get_strided_indirect
+    call_assert(prif_init_called_previously)
     call get_strided_helper( &
         image_num = image_num, &
         remote_ptr = remote_ptr, &
@@ -248,6 +252,7 @@ contains
   end procedure
 
   module procedure prif_put_strided_indirect
+    call_assert(prif_init_called_previously)
     call put_strided_helper( &
         image_num = image_num, &
         remote_ptr = remote_ptr, &
@@ -320,6 +325,7 @@ contains
   end procedure
 
   module procedure prif_put_strided_indirect_with_notify_indirect
+    call_assert(prif_init_called_previously)
     call put_strided_helper( &
         image_num = image_num, &
         remote_ptr = remote_ptr, &

--- a/src/caffeine/events_s.F90
+++ b/src/caffeine/events_s.F90
@@ -24,6 +24,7 @@ contains
   end procedure
 
   module procedure prif_event_post_indirect
+    call_assert(prif_init_called_previously)
     call_assert_describe(image_num > 0 .and. image_num <= initial_team%num_images, "image_num not within valid range")
 
     call caf_event_post(image_num, event_var_ptr, &
@@ -35,6 +36,7 @@ contains
   module procedure prif_event_wait
     integer(c_int64_t) :: threshold
 
+    call_assert(prif_init_called_previously)
     if (present(until_count)) then
       threshold = MAX(until_count, 1_c_int64_t)
     else
@@ -47,6 +49,7 @@ contains
   end procedure
 
   module procedure prif_event_query
+    call_assert(prif_init_called_previously)
     call caf_event_query(event_var_ptr, count) 
 
     if (present(stat)) stat = 0
@@ -55,6 +58,7 @@ contains
   module procedure prif_notify_wait
     integer(c_int64_t) :: threshold
 
+    call_assert(prif_init_called_previously)
     if (present(until_count)) then
       threshold = MAX(until_count, 1_c_int64_t)
     else

--- a/src/caffeine/locks_s.F90
+++ b/src/caffeine/locks_s.F90
@@ -1,5 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
+
+#include "assert_macros.h"
+
 submodule(prif:prif_private_s) locks_s
   ! DO NOT ADD USE STATEMENTS HERE
   ! All use statements belong in prif_private_s.F90
@@ -14,6 +17,7 @@ contains
   end procedure
 
   module procedure prif_lock_indirect
+    call_assert(prif_init_called_previously)
     call unimplemented("prif_lock_indirect")
 
     if (present(stat)) stat = 0
@@ -26,6 +30,7 @@ contains
   end procedure
 
   module procedure prif_unlock_indirect
+    call_assert(prif_init_called_previously)
     call unimplemented("prif_unlock_indirect")
 
     if (present(stat)) stat = 0

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -27,6 +27,7 @@ submodule(prif) prif_private_s
   type(prif_team_descriptor), target :: initial_team
   type(prif_team_type) :: current_team
   integer(c_intptr_t) :: total_heap_size, non_symmetric_heap_size
+  logical, save :: prif_init_called_previously = .false.
 
   interface
 
@@ -548,6 +549,8 @@ contains
     integer(c_int) :: i, epp(15)
     type(prif_coarray_descriptor), pointer :: cdp
 
+    call assert_always(prif_init_called_previously, "Invalid call to a PRIF subroutine before prif::prif_init")
+
     call assert_always(c_associated(coarray_handle%info), "unassociated info pointer in prif_coarray_handle")
     cdp => handle_to_cdp(coarray_handle)
     associate(corank => cdp%corank)
@@ -578,6 +581,7 @@ contains
     logical :: result_, known_active_
     integer :: i
 
+    call assert_always(prif_init_called_previously, "Invalid call to a PRIF subroutine before prif::prif_init")
     call assert_always(associated(team%info), "unassociated info pointer in prif_team_type")
 
     ! check for invalid cycles in the team hierarchy

--- a/src/caffeine/program_startup_s.F90
+++ b/src/caffeine/program_startup_s.F90
@@ -11,7 +11,9 @@ contains
 
   module procedure prif_init
     use ieee_arithmetic, only: ieee_inexact, ieee_set_flag
-    logical, save :: prif_init_called_previously = .false.
+    logical, save :: shadow_init = .false.
+
+    call_assert(shadow_init .eqv. prif_init_called_previously)
 
     if (prif_init_called_previously) then
        stat = PRIF_STAT_ALREADY_INIT
@@ -30,6 +32,9 @@ contains
        initial_team%num_images = caf_num_images(initial_team%gex_team)
        non_symmetric_heap_size = total_heap_size - initial_team%heap_size
 
+       prif_init_called_previously = .true.
+       shadow_init = .true.
+
        call_assert(team_check(current_team))
 
        call sync_init()
@@ -38,7 +43,6 @@ contains
        ! signalled from within the C-based initialization code above
        call ieee_set_flag(ieee_inexact, .false.)
 
-       prif_init_called_previously = .true.
        stat = 0
     end if
   end procedure

--- a/src/caffeine/program_termination_s.F90
+++ b/src/caffeine/program_termination_s.F90
@@ -1,5 +1,8 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
+
+#include "assert_macros.h"
+
 submodule(prif:prif_private_s) program_termination_s
   ! DO NOT ADD USE STATEMENTS HERE
   ! All use statements belong in prif_private_s.F90
@@ -32,6 +35,7 @@ contains
 
   module procedure prif_stop
 
+    call_assert(prif_init_called_previously)
     call flush_all()
 
     call prif_sync_all
@@ -87,6 +91,7 @@ contains
 
   module procedure prif_error_stop
       
+    call_assert(prif_init_called_previously)
     call flush_all()
 
     call run_callbacks(.true._c_bool, quiet, stop_code_int, stop_code_char)
@@ -135,6 +140,7 @@ contains
   end subroutine
 
   module procedure prif_fail_image
+    call_assert(prif_init_called_previously)
 #   ifndef CAF_FAIL_IMAGE_SUPPRESS_FLUSH
       call flush_all()
 #   endif

--- a/src/caffeine/sync_stmt_s.F90
+++ b/src/caffeine/sync_stmt_s.F90
@@ -29,6 +29,7 @@ contains
   end procedure
 
   module procedure prif_sync_memory
+    call_assert(prif_init_called_previously)
     call caf_sync_memory
     if (present(stat)) stat = 0
   end procedure


### PR DESCRIPTION


Many PRIF entry points begin with a call to internal helpers `team_check` or `coarray_handle_check`, so new assertions there cover a large fraction of the public entry points.

The rest are covered by strategic insertion of assertions near the entry point.

`prif_init_called_previously` is promoted to a module-level internal symbol to enable these assertions, and a new variable local to `prif_init` is used to detect potential discrepancies from memory corruption.