### PR TITLE
[NO REVIEW]: Restore LFortran testing of co_broadcast on sequence type

### DIFF
--- a/test/prif_co_broadcast_test.F90
+++ b/test/prif_co_broadcast_test.F90
@@ -52,8 +52,8 @@ contains
        test_description_t("broadcasting a default integer scalar with no optional arguments present", usher(broadcast_default_integer_scalar)) &
       ,test_description_t("prif_co_broadcast of a derived type scalar with no allocatable components", usher(broadcast_derived_type)) &
       ,test_description_t("prif_co_broadcast_cptr of a derived type scalar with no allocatable components" &
-#   if __LFORTRAN__
-       ! test disabled for LFortran issue 11191
+#   if __LFORTRAN__ && __LFORTRAN_MAJOR__ == 0 && __LFORTRAN_MINOR__ <= 63
+       ! test disabled for LFortran issue 11191, fixed after v0.63
 #   else
         , usher(broadcast_derived_type_cptr) &
 #   endif


### PR DESCRIPTION
LFortran issue 11191 is resolved in their main branch, so this test should work in the next release of LFortran.