### PR TITLE
Fix -DCAF_IMPORT_TEAM_CONSTANTS and tweak use statements

### DIFF
--- a/example/hello.F90
+++ b/example/hello.F90
@@ -1,5 +1,5 @@
 program hello_world
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_this_image_no_coarray &

--- a/example/support-test/error_stop_with_character_code.F90
+++ b/example/support-test/error_stop_with_character_code.F90
@@ -1,5 +1,5 @@
 program error_stop_with_character_code
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_stop &

--- a/example/support-test/error_stop_with_integer_code.F90
+++ b/example/support-test/error_stop_with_integer_code.F90
@@ -1,5 +1,5 @@
 program error_stop_with_integer_code
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_stop &

--- a/example/support-test/error_stop_with_no_code.F90
+++ b/example/support-test/error_stop_with_no_code.F90
@@ -1,5 +1,5 @@
 program error_stop_with_no_code
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_stop &

--- a/example/support-test/exit_case.F90
+++ b/example/support-test/exit_case.F90
@@ -1,6 +1,6 @@
 program hello_world
-  use iso_c_binding, only: c_bool
-  use iso_fortran_env, only: output_unit,error_unit
+  use, intrinsic :: iso_c_binding, only: c_bool
+  use, intrinsic :: iso_fortran_env, only: output_unit,error_unit
   use prif, only : &
      prif_init &
     ,prif_this_image_no_coarray &

--- a/example/support-test/fail_image.F90
+++ b/example/support-test/fail_image.F90
@@ -1,5 +1,5 @@
 program fail_image
-  use iso_c_binding, only: c_bool, c_int
+  use, intrinsic :: iso_c_binding, only: c_bool, c_int
   use prif, only : &
      prif_init &
     ,prif_num_images &

--- a/example/support-test/out_of_memory.F90
+++ b/example/support-test/out_of_memory.F90
@@ -1,6 +1,6 @@
 program out_of_memory
   use unit_test_parameters_m, only: null_final_proc
-  use iso_c_binding, only: c_bool, c_size_t, c_ptr, c_int64_t
+  use, intrinsic :: iso_c_binding, only: c_bool, c_size_t, c_ptr, c_int64_t
   use prif
   implicit none
 

--- a/example/support-test/register_stop_callback.F90
+++ b/example/support-test/register_stop_callback.F90
@@ -1,5 +1,5 @@
 program register_stop_callback
-    use iso_c_binding, only: c_bool, c_int
+    use, intrinsic :: iso_c_binding, only: c_bool, c_int
     use prif, only : &
        prif_init, &
        prif_register_stop_callback, &

--- a/example/support-test/stop_with_character_code.F90
+++ b/example/support-test/stop_with_character_code.F90
@@ -1,5 +1,5 @@
 program stop_with_character_code
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_stop &

--- a/example/support-test/stop_with_integer_code.F90
+++ b/example/support-test/stop_with_integer_code.F90
@@ -1,5 +1,5 @@
 program stop_with_integer_code
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_stop &

--- a/example/support-test/stop_with_no_code.F90
+++ b/example/support-test/stop_with_no_code.F90
@@ -1,5 +1,5 @@
 program stop_with_no_code
-  use iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_bool
   use prif, only : &
      prif_init &
     ,prif_stop &

--- a/src/caffeine/co_max_s.F90
+++ b/src/caffeine/co_max_s.F90
@@ -5,7 +5,7 @@
 
 module caf_prif_co_max_helper
   !! F23 C1807: bind(c) callbacks written in Fortran must appear in a top-level module
-  use iso_c_binding, only: c_ptr, c_size_t, c_char, c_f_pointer
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_size_t, c_char, c_f_pointer
   implicit none
 
 contains

--- a/src/caffeine/co_min_s.F90
+++ b/src/caffeine/co_min_s.F90
@@ -5,7 +5,7 @@
 
 module caf_prif_co_min_helper
   !! F23 C1807: bind(c) callbacks written in Fortran must appear in a top-level module
-  use iso_c_binding, only: c_ptr, c_size_t, c_char, c_f_pointer
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_size_t, c_char, c_f_pointer
   implicit none
 
 contains

--- a/src/caffeine/prif_private_s.F90
+++ b/src/caffeine/prif_private_s.F90
@@ -6,11 +6,11 @@
 submodule(prif) prif_private_s
   use assert_m
 
-  use iso_fortran_env, only : &
+  use, intrinsic :: iso_fortran_env, only : &
         output_unit, &
         error_unit
 
-  use iso_c_binding, only: &
+  use, intrinsic :: iso_c_binding, only: &
         c_associated, &
         c_f_pointer, &
         c_f_procpointer, &

--- a/src/caffeine/program_startup_s.F90
+++ b/src/caffeine/program_startup_s.F90
@@ -10,7 +10,7 @@ submodule(prif:prif_private_s) program_startup_s
 contains
 
   module procedure prif_init
-    use ieee_arithmetic, only: ieee_inexact, ieee_set_flag
+    use, intrinsic :: ieee_arithmetic, only: ieee_inexact, ieee_set_flag
     logical, save :: shadow_init = .false.
 
     call_assert(shadow_init .eqv. prif_init_called_previously)

--- a/src/caffeine/unit_test_parameters_m.F90
+++ b/src/caffeine/unit_test_parameters_m.F90
@@ -38,7 +38,7 @@ contains
 
   ! Retrieve an environment parameter or its default value
   subroutine getenv_withdefault(key, default, result)
-    use iso_fortran_env, only: error_unit
+    use, intrinsic :: iso_fortran_env, only: error_unit
     character(len=*), intent(in) :: key, default
     character(len=:), allocatable, intent(inout) :: result
     character(len=:), allocatable :: suffix

--- a/src/caffeine/unit_test_parameters_m.F90
+++ b/src/caffeine/unit_test_parameters_m.F90
@@ -4,7 +4,7 @@
 #include "version.h"
 
 module unit_test_parameters_m
-  use iso_c_binding, only: c_int, c_funptr, c_null_funptr
+  use, intrinsic :: iso_c_binding, only: c_int, c_funptr, c_null_funptr
   use prif, only: prif_sync_all, prif_this_image_no_coarray
 #if CAF_PRIF_VERSION >= 8
   use prif, only: prif_coarray_cleanup_interface

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -6,17 +6,18 @@
 
 module prif
 
-  use iso_c_binding, only: &
+  use, intrinsic :: iso_c_binding, only: &
       c_char, c_int, c_bool, c_intptr_t, c_ptr, &
       c_funptr, c_size_t, c_ptrdiff_t, c_null_ptr, c_int64_t
 #if HAVE_LOGICAL64
-  use iso_fortran_env, only: logical64
+  use, intrinsic :: iso_fortran_env, only: logical64
 #endif
 #if CAF_IMPORT_ATOMIC_CONSTANTS
-  use iso_fortran_env, only: ATOMIC_INT_KIND, ATOMIC_LOGICAL_KIND
+  use, intrinsic :: iso_fortran_env, only: &
+      ATOMIC_INT_KIND, ATOMIC_LOGICAL_KIND
 #endif
 #if CAF_IMPORT_STAT_CONSTANTS
-  use iso_fortran_env, only: &
+  use, intrinsic :: iso_fortran_env, only: &
       STAT_FAILED_IMAGE, STAT_STOPPED_IMAGE, &
       STAT_LOCKED, STAT_LOCKED_OTHER_IMAGE, &
       STAT_UNLOCKED, STAT_UNLOCKED_FAILED_IMAGE

--- a/src/prif.F90
+++ b/src/prif.F90
@@ -22,7 +22,10 @@ module prif
       STAT_UNLOCKED, STAT_UNLOCKED_FAILED_IMAGE
 #endif
 #if CAF_IMPORT_TEAM_CONSTANTS
-  use iso_fortran_env, only: CURRENT_TEAM, INITIAL_TEAM, PARENT_TEAM
+  use, intrinsic :: iso_fortran_env, only: &
+      ISO_FORTRAN_ENV_CURRENT_TEAM => CURRENT_TEAM, &
+      ISO_FORTRAN_ENV_INITIAL_TEAM => INITIAL_TEAM, &
+      ISO_FORTRAN_ENV_PARENT_TEAM  => PARENT_TEAM
 #endif
 
   implicit none
@@ -91,9 +94,9 @@ module prif
 
 #if CAF_IMPORT_TEAM_CONSTANTS
   integer(c_int), parameter, public :: &
-    PRIF_CURRENT_TEAM               = CURRENT_TEAM, &
-    PRIF_INITIAL_TEAM               = INITIAL_TEAM, &
-    PRIF_PARENT_TEAM                = PARENT_TEAM
+    PRIF_CURRENT_TEAM               = ISO_FORTRAN_ENV_CURRENT_TEAM, &
+    PRIF_INITIAL_TEAM               = ISO_FORTRAN_ENV_INITIAL_TEAM, &
+    PRIF_PARENT_TEAM                = ISO_FORTRAN_ENV_PARENT_TEAM
 #else
   integer(c_int), parameter, public :: &
     PRIF_CURRENT_TEAM               = 101, &

--- a/test/julienne-driver.F90
+++ b/test/julienne-driver.F90
@@ -4,7 +4,7 @@
 program test_suite_driver
   use julienne_m
   use prif, only: prif_this_image_no_coarray, prif_num_images, prif_sync_all, prif_co_sum, prif_error_stop
-  use iso_c_binding, only: c_int, c_bool, c_funloc, c_funptr, c_f_procpointer
+  use, intrinsic :: iso_c_binding, only: c_int, c_bool, c_funloc, c_funptr, c_f_procpointer
   use prif_init_test_m, only : prif_init_test_t, check_caffeination
   use prif_num_images_test_m, only : prif_num_images_test_t
   use prif_this_image_no_coarray_test_m, only : prif_this_image_no_coarray_test_t

--- a/test/prif_allocate_test.F90
+++ b/test/prif_allocate_test.F90
@@ -3,7 +3,7 @@
 
 module prif_allocate_test_m
 # include "test-uses-alloc.F90"
-  use iso_c_binding, only: c_char
+  use, intrinsic :: iso_c_binding, only: c_char
   use prif, only : &
       prif_num_images, prif_size_bytes, &
       prif_set_context_data, prif_get_context_data, prif_local_data_pointer, &

--- a/test/prif_co_broadcast_test.F90
+++ b/test/prif_co_broadcast_test.F90
@@ -1,7 +1,7 @@
 #include "test-utils.F90"
 
 module prif_co_broadcast_test_m
-  use iso_c_binding, only: c_loc, c_size_t
+  use, intrinsic :: iso_c_binding, only: c_loc, c_size_t
   use prif, only : prif_co_broadcast, prif_co_broadcast_cptr, prif_num_images, prif_this_image_no_coarray
   use julienne_m, only : &
      usher &

--- a/test/prif_co_max_test.F90
+++ b/test/prif_co_max_test.F90
@@ -1,5 +1,5 @@
 module prif_co_max_test_m
-  use iso_c_binding, only: c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double
+  use, intrinsic :: iso_c_binding, only: c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double
   use prif, only : prif_co_max, prif_co_max_character, prif_this_image_no_coarray, prif_num_images
   use julienne_m, only: &
     operator(.all.) &

--- a/test/prif_co_min_test.F90
+++ b/test/prif_co_min_test.F90
@@ -1,5 +1,5 @@
 module prif_co_min_test_m
-  use iso_c_binding, only: c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double
+  use, intrinsic :: iso_c_binding, only: c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double
   use prif, only : prif_co_min, prif_co_min_character, prif_this_image_no_coarray, prif_num_images
   use julienne_m, only: &
     operator(.all.) &

--- a/test/prif_co_reduce_test.F90
+++ b/test/prif_co_reduce_test.F90
@@ -2,7 +2,7 @@
 #include "julienne-assert-macros.h"
 
 module prif_co_reduce_test_m
-  use iso_c_binding, only: c_ptr, c_funptr, c_size_t, c_f_pointer, c_f_procpointer, c_funloc, c_loc, c_null_ptr, c_associated, c_int8_t
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_funptr, c_size_t, c_f_pointer, c_f_procpointer, c_funloc, c_loc, c_null_ptr, c_associated, c_int8_t
   use prif, only : prif_co_reduce, prif_co_reduce_cptr, prif_num_images, prif_this_image_no_coarray, prif_operation_wrapper_interface
   use julienne_m, only : &
      call_julienne_assert_ &

--- a/test/prif_co_sum_test.F90
+++ b/test/prif_co_sum_test.F90
@@ -1,5 +1,5 @@
 module prif_co_sum_test_m
-    use iso_c_binding, only: c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double
+    use, intrinsic :: iso_c_binding, only: c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double
     use prif, only : prif_co_sum, prif_num_images, prif_this_image_no_coarray
     use julienne_m, only: &
        operator(.all.) &

--- a/test/prif_image_queries_test.F90
+++ b/test/prif_image_queries_test.F90
@@ -1,5 +1,5 @@
 module prif_image_queries_test_m
-    use iso_c_binding, only: c_int
+    use, intrinsic :: iso_c_binding, only: c_int
     use prif, only : prif_image_status, prif_stopped_images, prif_failed_images, PRIF_STAT_FAILED_IMAGE, PRIF_STAT_STOPPED_IMAGE
     use prif, only : prif_num_images
     use julienne_m, only: &

--- a/test/prif_sync_images_test.F90
+++ b/test/prif_sync_images_test.F90
@@ -1,5 +1,5 @@
 module prif_sync_images_test_m
-    use iso_c_binding, only: c_int
+    use, intrinsic :: iso_c_binding, only: c_int
     use prif, only : prif_sync_images, prif_this_image_no_coarray, prif_num_images, prif_sync_all
     use julienne_m, only: test_description_t, test_diagnosis_t, test_result_t, test_t, usher
 

--- a/test/prif_teams_test.F90
+++ b/test/prif_teams_test.F90
@@ -3,7 +3,7 @@
 
 module prif_teams_test_m
 # include "test-uses-alloc.F90"
-    use iso_c_binding, only: c_char
+    use, intrinsic :: iso_c_binding, only: c_char
     use prif
     use julienne_m, only: test_description_t, test_diagnosis_t, test_result_t, test_t, string_t, usher &
       ,operator(.also.), operator(.isAtLeast.), operator(.isAtMost.), operator(.equalsExpected.), operator(//)

--- a/test/prif_threaded_test.F90
+++ b/test/prif_threaded_test.F90
@@ -2,7 +2,7 @@
 
 module prif_threaded_test_m
 # include "test-uses-alloc.F90"
-    use iso_c_binding, only: c_funptr, c_funloc, c_f_procpointer
+    use, intrinsic :: iso_c_binding, only: c_funptr, c_funloc, c_f_procpointer
     use prif, only: &
             prif_notify_type, prif_notify_wait, prif_put_with_notify, &
             prif_this_image_no_coarray, prif_num_images, &

--- a/test/prif_types_test.F90
+++ b/test/prif_types_test.F90
@@ -1,8 +1,8 @@
 #include "test-utils.F90"
 
 module prif_types_test_m
-    use iso_fortran_env, only: int8
-    use iso_c_binding, only: c_ptr, c_loc, c_intptr_t
+    use, intrinsic :: iso_fortran_env, only: int8
+    use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_intptr_t
     use prif, only: prif_team_type, prif_event_type, prif_notify_type, prif_lock_type, prif_critical_type, prif_coarray_handle, prif_this_image_no_coarray
     use julienne_m, only: test_description_t, test_diagnosis_t, test_result_t, test_t, string_t, usher &
        ,operator(.all.), operator(.also.), operator(.equalsExpected.), operator(.greaterThan.), operator(.isAtMost.), operator(//)

--- a/test/test-uses-alloc.F90
+++ b/test/test-uses-alloc.F90
@@ -40,7 +40,7 @@ use prif, only : &
 #  define final_proc(proc) c_funloc(proc)
 #endif
 
-  use iso_c_binding, only: &
+  use, intrinsic :: iso_c_binding, only: &
       c_ptr, c_int, c_int64_t, c_size_t, c_intptr_t, &
       c_null_funptr, c_null_ptr, &
       c_associated, c_f_pointer, c_funloc, c_loc, c_sizeof


### PR DESCRIPTION
A semi-urgent fix for a defect in the `-DCAF_IMPORT_TEAM_CONSTANTS` setting, [discovered by LFortran](https://github.com/bonachea/lfortran/actions/runs/29471968098/job/87536754475).

Also, tweak all intrinsic module uses to explicitly require intrinsic
