### PR TITLE
[NO REVIEW] Repair assertions for LFortran

### DIFF
--- a/manifest/fpm.toml.template
+++ b/manifest/fpm.toml.template
@@ -6,7 +6,7 @@ maintainer = "fortran@lbl.gov"
 copyright = "2021-2026 The Regents of the University of California, through Lawrence Berkeley National Laboratory"
 
 [dev-dependencies]
-assert = {git = "https://github.com/berkeleylab/assert.git", tag = "3.1.0"}
+assert = {git = "https://github.com/berkeleylab/assert.git", tag = "3.1.2"}
 julienne = {git = "https://github.com/berkeleylab/julienne.git", tag = "4.1.0"}
 
 [install]

--- a/src/caffeine/program_startup_s.F90
+++ b/src/caffeine/program_startup_s.F90
@@ -63,10 +63,14 @@ contains
     pure subroutine assert_callback_error_stop(stop_code_char)
       implicit none
       character(len=*), intent(in) :: stop_code_char
-      character(len=:), allocatable, target :: tmp
-      tmp = stop_code_char
-    
-      call caf_fatal_error(tmp)
+#     if __LFORTRAN__
+        ! LFortran currently miscompiles the call to caf_fatal_error below
+        error stop stop_code_char, quiet=.false.
+#     else
+        character(len=:), allocatable, target :: tmp
+        tmp = stop_code_char
+        call caf_fatal_error(tmp)
+#     endif
     end subroutine
 #else 
     subroutine assert_init()  


### PR DESCRIPTION
The assertion failure path for LFortran was previously hitting a segmentation fault (with no output). Consequently Caffeine's many assertion checks were not being correctly reported when triggered under LFortran.

Deploy fixes and workaround to ensure high-quality assertion failure output with LFortran.

CC: @Jainam-not-a-robot 