### PR TITLE
Fix #358: install.sh failure with FC in a directory name matching `flang-[1-9][0-9]`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -367,7 +367,8 @@ echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
 
 FPM_FC="$($REALPATH $(command -v $FC))"
 if [[ $FPM_FC == *flang* ]]; then
-  FPM_FC=${FPM_FC/flang-[1-9][0-9]*/flang-new}
+  # issue #358: pattern must only match the end, to avoid false positives on directory components
+  FPM_FC=${FPM_FC/%flang-[1-9][0-9]/flang-new}
 fi
 FPM_CC="$($REALPATH $(command -v $CC))"
 


### PR DESCRIPTION
Fixes #358