### PR TITLE
[NO REVIEW] CI: Update to flang 23.1.0 release and LFortran release v0.65.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,14 @@ jobs:
       run: |
         # silence Homebrew tap trust warnings:
         (set +e ; brew untap -f aws/tap hashicorp/tap 2>&1 | perl -pe 's/#*.warning./warn: /' ; brew trust azure/bicep )
+        # set some Homebrew knobs to accelerate installation
+        # but only when we are not simulating the user environment brew-via-install workflow
+        if [[ -z "${{ matrix.brew_via_install }}" ]] ; then
+          echo HOMEBREW_NO_ANALYTICS=1 >> "$GITHUB_ENV"
+          echo HOMEBREW_NO_AUTO_UPDATE=1 >> "$GITHUB_ENV"
+          echo HOMEBREW_NO_GITHUB_API=1 >> "$GITHUB_ENV"
+          echo HOMEBREW_NO_INSTALL_CLEANUP=1 >> "$GITHUB_ENV"
+        fi
 
     - name: Install macOS Dependencies
       if: ${{ contains(matrix.os, 'macos') && !matrix.brew_via_install }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,11 @@ jobs:
 
           - os: ubuntu-22.04
             compiler: lfortran
+            version: 0.65
+            container: ghcr.io/lfortran/lfortran:v0.65.0
+
+          - os: ubuntu-22.04
+            compiler: lfortran
             version: 0.64
             container: ghcr.io/lfortran/lfortran:v0.64.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Set default configuration variables
         id: vars
-        run: echo "BREW_FLANG_VERSION=22" >> $GITHUB_OUTPUT
+        run: echo "BREW_FLANG_VERSION=23" >> $GITHUB_OUTPUT
 
   build:
     name: ${{ matrix.compiler }}-${{ matrix.version || needs.setup.outputs.BREW_FLANG_VERSION }} ${{ ( matrix.network != 'smp' && matrix.network ) || '' }} (${{ matrix.os }}) ${{ matrix.label }}
@@ -115,12 +115,12 @@ jobs:
           - os: ubuntu-24.04-arm
             compiler: flang
             version: 23
-            container: phhargrove/llvm-flang:23.1.0_rc3-latest-arm64
+            container: phhargrove/llvm-flang:23.1.0-latest-arm64
 
           - os: ubuntu-24.04
             compiler: flang
             version: 23
-            container: phhargrove/llvm-flang:23.1.0_rc3-latest
+            container: phhargrove/llvm-flang:23.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: 22
@@ -234,12 +234,12 @@ jobs:
             compiler: flang
             network: udp
             version: 23
-            container: phhargrove/llvm-flang:23.1.0_rc3-latest-arm64
+            container: phhargrove/llvm-flang:23.1.0-latest-arm64
           - os: ubuntu-24.04
             compiler: flang
             version: 23
             network: udp
-            container: phhargrove/llvm-flang:23.1.0_rc3-latest
+            container: phhargrove/llvm-flang:23.1.0-latest
           - os: ubuntu-24.04
             compiler: flang
             version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,15 +84,16 @@ jobs:
           - os: macos-15
             compiler: flang
             brew_via_install: 1
-          - os: macos-15-intel
-            compiler: flang
-            brew_via_install: 1
           - os: macos-26
             compiler: flang
             brew_via_install: 1
-          - os: macos-26-intel
-            compiler: flang
-            brew_via_install: 1
+          # flang 23 bottle missing for Sonoma/x86_64
+          #- os: macos-15-intel
+          #  compiler: flang
+          #  brew_via_install: 1
+          #- os: macos-26-intel
+          #  compiler: flang
+          #  brew_via_install: 1
 
           - os: ubuntu-24.04
             compiler: flang
@@ -207,13 +208,14 @@ jobs:
             version: 14
             network: udp
 
-          - os: macos-15-intel
-            compiler: flang
-            network: udp
+          # flang 23 bottle missing for Sonoma/x86_64
+          #- os: macos-15-intel
+          #  compiler: flang
+          #  network: udp
+          #- os: macos-26-intel
+          #  compiler: flang
+          #  network: udp
           - os: macos-15
-            compiler: flang
-            network: udp
-          - os: macos-26-intel
             compiler: flang
             network: udp
           - os: macos-26

--- a/app/native-multi-image.F90
+++ b/app/native-multi-image.F90
@@ -362,9 +362,12 @@ program native_multi_image
 
   integer :: me, ni, peer, i, ia(3)
   character(len=10) :: c, ca(3)
-# if HAVE_TEAM
+# if HAVE_FORM_TEAM
   integer :: team_id
   type(TEAM_TYPE) :: subteam
+# endif
+# if HAVE_GET_TEAM
+  type(TEAM_TYPE) :: tmpteam
 # endif
 # if HAVE_TEAM_TYPE
   type(TEAM_TYPE) :: default_team
@@ -511,9 +514,18 @@ program native_multi_image
 # endif
 # if HAVE_GET_TEAM
     STATUS("Testing GET_TEAM...")
-    subteam = GET_TEAM(CURRENT_TEAM)
-    subteam = GET_TEAM(INITIAL_TEAM)
-    subteam = GET_TEAM()
+    tmpteam = GET_TEAM(CURRENT_TEAM)
+#   if HAVE_THIS_IMAGE_TEAM
+      CHECK_VALI(THIS_IMAGE(tmpteam),THIS_IMAGE())
+#   endif
+    tmpteam = GET_TEAM(INITIAL_TEAM)
+#   if HAVE_NUM_IMAGES_TEAM
+      CHECK_VALI(NUM_IMAGES(tmpteam),NUM_IMAGES())
+#   endif
+    tmpteam = GET_TEAM()
+#   if HAVE_TEAM_NUMBER_TEAM
+      CHECK_VALI(TEAM_NUMBER(tmpteam),-1)
+#   endif
 # endif
 # if HAVE_TEAM_NUMBER
     STATUS("Testing TEAM_NUMBER...")

--- a/app/print-native-flags.F90
+++ b/app/print-native-flags.F90
@@ -65,14 +65,10 @@ subroutine write_flags
 #  endif
 #elif __LFORTRAN__
 #  if   __LFORTRAN_MAJOR__ == 0 && __LFORTRAN_MINOR__ <= 63
-   ! no multi-image support
-#  elif __LFORTRAN_MAJOR__ > 0 ||  \
-        (__LFORTRAN_MAJOR__ == 0 && __LFORTRAN_MINOR__ >= 64 )
-   if (INDEX(COMPILER_VERSION(), 'version 0.64') /= 0 .and. &
-       INDEX(COMPILER_VERSION(), '-g') == 0) then 
-     ! LFortran release 0.64
+   ! no multi-image support before 0.64.0
+#  else
      call set("--coarray=true")
-
+#    if  __LFORTRAN_MAJOR__ == 0 && __LFORTRAN_MINOR__ == 64
      call no("TEAM")
 
      call no("ALLOC_COARRAY")
@@ -82,10 +78,25 @@ subroutine write_flags
      call no("EVENT")
      call no("LOCK")
      call no("NOTIFY")
+#    else
+   if (INDEX(COMPILER_VERSION(), 'version 0.65') /= 0 .and. &
+       INDEX(COMPILER_VERSION(), '-g') == 0) then 
+     ! LFortran release 0.65
+     call no("GET_TEAM")
+     call no("NUM_IMAGES_TEAM")
+     call no("THIS_IMAGE_TEAM")
+     call no("TEAM_NUMBER")
+
+     call no("ALLOC_COARRAY_CLEANUP")
+     call no("IMAGE_INDEX")
+     call no("THIS_IMAGE_COARRAY")
+     call no("PUTGET_INTRINSIC_ARRAY_CONTIG")
+
+     call no("EVENT")
+     call no("LOCK")
+     call no("NOTIFY")
    else 
      ! LFortran git snapshot or newer, assume latest we know about
-     call set("--coarray=true")
-
      call no("GET_TEAM")
      call no("NUM_IMAGES_TEAM")
      call no("THIS_IMAGE_TEAM")
@@ -100,6 +111,7 @@ subroutine write_flags
      call no("LOCK")
      call no("NOTIFY")
    end if
+#  endif
 #  endif
 #elif NAGFOR
    if (.not. stand_alone) return

--- a/app/print-native-flags.F90
+++ b/app/print-native-flags.F90
@@ -153,8 +153,6 @@ subroutine write_flags
      call set("-DTYPES_PRIF_COMPLIANT=0")
 
      call no("NOTIFY") ! missing F2023 feature
-     call no("FORM_TEAM") ! runtime errors on FORM TEAM
-     call no("CHANGE_TEAM") ! runtime errors on FORM TEAM
      call no("TEAM_TYPE") ! avoid runtime errors from CHECK_TYPE_COMPLIANCE
      call set("-DIGNORE_FAILURES=4") ! CO_MIN/CO_MAX(character) get the wrong answer at runtime (no change)
 #  endif


### PR DESCRIPTION
Note the original flang 23.1.0 Homebrew bottle for macOS was [highly defective](https://github.com/Homebrew/homebrew-core/issues/301233) and demonstrated multiple runtime failures in Caffeine when the broken optimizer was enabled. Please ensure you are using bottle version `23.1.0_1` (where the trailing `_1` is the fixed version).

macOS + Intel bottles for flang 23 are currently unavailable, so those configs are (temporarily?) disabled.

Also deploy a workaround for an ifx bug in `team_type`, allowing it to run more of the native-multi-image test in stand-alone mode.